### PR TITLE
Add undocumented mouse event properties and other minor fixes

### DIFF
--- a/markdown/api/event/mouse/index.markdown
+++ b/markdown/api/event/mouse/index.markdown
@@ -51,6 +51,14 @@ Mouse events will not be received while the mouse cursor is outside of the appli
 
 #### [event.isMiddleButtonDown][api.event.mouse.isMiddleButtonDown]
 
+#### [event.isCtrlDown][api.event.mouse.isCtrlDown]
+
+#### [event.isShiftDown][api.event.mouse.isShiftDown]
+
+#### [event.isAltDown][api.event.mouse.isAltDown]
+
+#### [event.isCommandDown][api.event.mouse.isCommandDown]
+
 #### [event.name][api.event.mouse.name]
 
 #### [event.time][api.event.mouse.time]
@@ -58,4 +66,28 @@ Mouse events will not be received while the mouse cursor is outside of the appli
 #### [event.x][api.event.mouse.x]
 
 #### [event.y][api.event.mouse.y]
+
+#### [event.scrollX][api.event.mouse.scrollX]
+
+#### [event.scrollY][api.event.mouse.scrollY]
+
+#### [event.type][api.event.mouse.type]
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.type == "down" then
+        if event.isPrimaryButtonDown then
+            print( "Left mouse button clicked." )
+        elseif event.isSecondaryButtonDown then
+            print( "Right mouse button clicked." )        
+        end
+    end
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````
 

--- a/markdown/api/event/mouse/isAltDown.markdown
+++ b/markdown/api/event/mouse/isAltDown.markdown
@@ -1,0 +1,29 @@
+
+# event.isAltDown
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, isAltDown
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Indicates if the alt button was held down at the time the mouse event occurred.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.isAltDown then
+        -- The alt button is currently pressed down.
+    else
+        -- The alt button is not being pressed.
+    end
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/isCommandDown.markdown
+++ b/markdown/api/event/mouse/isCommandDown.markdown
@@ -1,0 +1,29 @@
+
+# event.isCommandDown
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, isCommandDown
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Indicates if the command or Windows button was held down at the time the mouse event occurred.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.isCommandDown then
+        -- The command/Windows button is currently pressed down.
+    else
+        -- The command/Windows button is not being pressed.
+    end
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/isCtrlDown.markdown
+++ b/markdown/api/event/mouse/isCtrlDown.markdown
@@ -1,0 +1,29 @@
+
+# event.isCtrlDown
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, isCtrlDown
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Indicates if the ctrl button was held down at the time the mouse event occurred.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.isCtrlDown then
+        -- The ctrl button is currently pressed down.
+    else
+        -- The ctrl button is not being pressed.
+    end
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/isShiftDown.markdown
+++ b/markdown/api/event/mouse/isShiftDown.markdown
@@ -1,0 +1,29 @@
+
+# event.isShiftDown
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, isShiftDown
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+Indicates if the shift button was held down at the time the mouse event occurred.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.isShiftDown then
+        -- The shift button is currently pressed down.
+    else
+        -- The shift button is not being pressed.
+    end
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/scrollX.markdown
+++ b/markdown/api/event/mouse/scrollX.markdown
@@ -1,0 +1,31 @@
+
+# event.scrollX
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Number][api.type.Number]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, scrollX
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The mouse scroll's current __x scrolling__ value. This value depends on user mouse settings.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.type == "scroll" then
+        if event.scrollX < 0 then
+            print( "Mouse is scrolling left with a value of " .. event.scrollX .. "." )
+        elseif event.scrollX > 0 then
+            print( "Mouse is scrolling right with a value of " .. event.scrollX .. "." )
+        end
+    end
+end
+
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/scrollY.markdown
+++ b/markdown/api/event/mouse/scrollY.markdown
@@ -1,0 +1,31 @@
+
+# event.scrollY
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Number][api.type.Number]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, scrollY
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The mouse scroll's current __y scrolling__ value. This value depends on user mouse settings.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    if event.type == "scroll" then
+        if event.scrollY < 0 then
+            print( "Mouse is scrolling up with a value of " .. event.scrollY .. "." )
+        elseif event.scrollY > 0 then
+            print( "Mouse is scrolling down with a value of " .. event.scrollY .. "." )
+        end
+    end
+end
+
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/mouse/type.markdown
+++ b/markdown/api/event/mouse/type.markdown
@@ -1,0 +1,30 @@
+
+# event.type
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [String][api.type.String]
+> __Event__             [mouse][api.event.mouse]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          mouse, type
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+A string identifying the type of mouse event that is occurring. Can be one of the following values:
+
+* `"down"` — indicates that a mouse button was pressed.
+* `"up"` — indicates that a mouse button was released.
+* `"move"` — indicates that the mouse is moving on the screen.
+* `"drag"` — indicates that the mouse is moving on the screen while a mouse button is pressed.
+
+## Example
+ 
+``````lua
+-- Called when a mouse event has been received.
+local function onMouseEvent( event )
+    print( "Mouse event type is: " .. event.type )
+end
+                             
+-- Add the mouse event listener.
+Runtime:addEventListener( "mouse", onMouseEvent )
+``````

--- a/markdown/api/event/touch/index.markdown
+++ b/markdown/api/event/touch/index.markdown
@@ -32,9 +32,13 @@ Multitouch events are an extension of single touch events. Multitouch is enabled
 
 #### [event.xStart][api.event.touch.xStart]
 
+#### [event.xDelta][api.event.touch.xDelta]
+
 #### [event.y][api.event.touch.y]
 
 #### [event.yStart][api.event.touch.yStart]
+
+#### [event.yDelta][api.event.touch.yDelta]
 
 
 ## Examples

--- a/markdown/api/event/touch/xDelta.markdown
+++ b/markdown/api/event/touch/xDelta.markdown
@@ -22,7 +22,7 @@ local function move( event )
         display.getCurrentStage():setFocus( event.target )
         event.target.xStart = event.target.x
         event.target.yStart = event.target.y
-		event.target.isFocus = true
+	event.target.isFocus = true
 
     elseif ( event.phase == "moved" ) then
         if ( event.target.isFocus ) then
@@ -32,7 +32,7 @@ local function move( event )
 
     else
         display.getCurrentStage():setFocus( nil )
-		event.target.isFocus = false
+	event.target.isFocus = false
 
     end
 end

--- a/markdown/api/event/touch/xDelta.markdown
+++ b/markdown/api/event/touch/xDelta.markdown
@@ -32,7 +32,7 @@ local function move( event )
 
     else
         display.getCurrentStage():setFocus( nil )
-	event.target.isFocus = false
+        event.target.isFocus = false
 
     end
 end

--- a/markdown/api/event/touch/xDelta.markdown
+++ b/markdown/api/event/touch/xDelta.markdown
@@ -1,0 +1,41 @@
+
+# event.xDelta
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Number][api.type.Number]
+> __Event__             [touch][api.event.touch]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          touch, xDelta
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The __x__ distance in screen coordinates between where the touch event began and its current coordinates.
+
+## Example
+
+``````lua
+local object = display.newRect( display.contentCenterX, display.contentCenterY, 100, 100 )
+
+local function move( event )
+    if ( event.phase == "began" ) then
+        display.getCurrentStage():setFocus( event.target )
+        event.target.xStart = event.target.x
+        event.target.yStart = event.target.y
+		event.target.isFocus = true
+
+    elseif ( event.phase == "moved" ) then
+        if ( event.target.isFocus ) then
+            event.target.x = event.target.xStart + event.xDelta
+            event.target.y = event.target.yStart + event.yDelta
+        end
+
+    else
+        display.getCurrentStage():setFocus( nil )
+		event.target.isFocus = false
+
+    end
+end
+
+object:addEventListener( "touch", move )
+``````

--- a/markdown/api/event/touch/yDelta.markdown
+++ b/markdown/api/event/touch/yDelta.markdown
@@ -22,7 +22,7 @@ local function move( event )
         display.getCurrentStage():setFocus( event.target )
         event.target.xStart = event.target.x
         event.target.yStart = event.target.y
-		event.target.isFocus = true
+	event.target.isFocus = true
 
     elseif ( event.phase == "moved" ) then
         if ( event.target.isFocus ) then
@@ -32,7 +32,7 @@ local function move( event )
 
     else
         display.getCurrentStage():setFocus( nil )
-		event.target.isFocus = false
+	event.target.isFocus = false
 
     end
 end

--- a/markdown/api/event/touch/yDelta.markdown
+++ b/markdown/api/event/touch/yDelta.markdown
@@ -32,7 +32,7 @@ local function move( event )
 
     else
         display.getCurrentStage():setFocus( nil )
-	event.target.isFocus = false
+        event.target.isFocus = false
 
     end
 end

--- a/markdown/api/event/touch/yDelta.markdown
+++ b/markdown/api/event/touch/yDelta.markdown
@@ -1,0 +1,41 @@
+
+# event.yDelta
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Number][api.type.Number]
+> __Event__             [touch][api.event.touch]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          touch, yDelta
+> --------------------- ------------------------------------------------------------------------------------------
+
+## Overview
+
+The __y__ distance in screen coordinates between where the touch event began and its current coordinates.
+
+## Example
+
+``````lua
+local object = display.newRect( display.contentCenterX, display.contentCenterY, 100, 100 )
+
+local function move( event )
+    if ( event.phase == "began" ) then
+        display.getCurrentStage():setFocus( event.target )
+        event.target.xStart = event.target.x
+        event.target.yStart = event.target.y
+		event.target.isFocus = true
+
+    elseif ( event.phase == "moved" ) then
+        if ( event.target.isFocus ) then
+            event.target.x = event.target.xStart + event.xDelta
+            event.target.y = event.target.yStart + event.yDelta
+        end
+
+    else
+        display.getCurrentStage():setFocus( nil )
+		event.target.isFocus = false
+
+    end
+end
+
+object:addEventListener( "touch", move )
+``````

--- a/markdown/guide/html5/plugins/index.markdown
+++ b/markdown/guide/html5/plugins/index.markdown
@@ -150,7 +150,7 @@ Here is all APIs to work with functions passed to JavaScript:
 
 * `LuaIsFunction` returns `boolean`. `true` if the passed value represents a valid Lua function _reference_.
 * `LuaCreateFunction` transforms a Lua function _reference_ to a callable JavaScript function and returns it.
-* `LuaReleaseFunciton` releases a _reference_ to an underlying Lua function. Calling released functions would result in a no-op (do nothing).
+* `LuaReleaseFunction` releases a _reference_ to an underlying Lua function. Calling released functions would result in a no-op (do nothing).
 
 Modus operandi is supposed to be as follows: receive a Lua function _reference_ as a parameter. Create a JavaScript function wrapper from this _reference_. Call the wrapper function, and release when it is no longer needed.
 


### PR DESCRIPTION
Added several undocumented, yet functional mouse event properties with examples. There's also mouse event clickCount property, but it didn't seem to work so I didn't add it.

Also fixed a tabulation error in touch event examples and a typo in HTML5 plugin documentation.

Finally, just as a note, the two "VK Direct Games plugin" sample links in https://docs.coronalabs.com/guide/html5/plugins/index.html#plugin-example don't work. They require signing in to BitBucket, but after signing BitBucket tells that I don't have access to said files.