### PR TITLE
Simplified table.insert examples and added usage details

### DIFF
--- a/markdown/api/library/table/insert.markdown
+++ b/markdown/api/library/table/insert.markdown
@@ -29,12 +29,20 @@ _[Number][api.type.Number]._ The index of the table at which the new element wil
 ##### value ~^(required)^~
 The new value to assign to be inserted into the table.
 
+## Gotchas
+Please note that when 2 parameters are provided the optional parameter `pos` is ignored.
 
 ## Example
 
 ``````lua
-local t = { 1, "three", 4, "five" }
-print ( table.concat(t, ", ") )  --> 1, three, 4, five
-table.insert( t, 2, "two" )  
-print ( table.concat(t, ", ") )  --> 1, two, three, 4, five
+local t = { 1, "jane" }
+
+table.insert( t, "doe" )
+--> 1, jane, doe
+
+table.insert( t, 2 )
+--> 1, jane, doe, 2	-- notice 'pos' parameter is ignored
+
+table.insert(t, 2, "miss")
+--> 1, miss, jane, doe, 2
 ``````

--- a/markdown/api/library/table/insert.markdown
+++ b/markdown/api/library/table/insert.markdown
@@ -24,13 +24,15 @@ Inserts a given value into a table. If a position is given, inserts the value be
 _[Table][api.type.Table]._ A table to which the new value will be added. When a table has an element inserted both the size of the array and the element indices are updated.
 
 ##### pos ~^(optional)^~
-_[Number][api.type.Number]._ The index of the table at which the new element will be inserted. The default value is the length of the table + 1 so that `table.insert(t,x)` inserts `x` at the end of table `t`. Note that it is faster to use the length operator: `t[#t + 1] = x`.
+_[Number][api.type.Number]._ The index of the table at which the new element will be inserted. The default value is the length of the table + 1 so that `table.insert(t,x)` inserts `x` at the end of table `t`.
 
 ##### value ~^(required)^~
 The new value to assign to be inserted into the table.
 
 ## Gotchas
-Please note that when 2 parameters are provided the optional parameter `pos` is ignored.
+When 2 parameters are provided, the optional parameter `pos` is ignored.
+
+Note that it is faster to use the length operator: `t[#t + 1] = x` when inserting new value to a table.
 
 ## Example
 


### PR DESCRIPTION
Added simplified new examples to table.insert(). Using table.concat() to print out table elements looked confusing so I removed that and used comments to show table elements. New examples also cover all three use cases.

Added table.insert() usage details to 'Gotchas' like the function ignoring the position parameter when called with 2 parameters instead of 3. Also, moved the usage note about the length operator being faster to 'Gotchas'.