### PR TITLE
Changed physics - working with display groups warning

### DIFF
--- a/markdown/api/library/table/insert.markdown
+++ b/markdown/api/library/table/insert.markdown
@@ -29,12 +29,20 @@ _[Number][api.type.Number]._ The index of the table at which the new element wil
 ##### value ~^(required)^~
 The new value to assign to be inserted into the table.
 
+## Gotchas
+Please note that when 2 parameters are provided the optional parameter `pos` is ignored.
 
 ## Example
 
 ``````lua
-local t = { 1, "three", 4, "five" }
-print ( table.concat(t, ", ") )  --> 1, three, 4, five
-table.insert( t, 2, "two" )  
-print ( table.concat(t, ", ") )  --> 1, two, three, 4, five
+local t = { 1, "jane" }
+
+table.insert( t, "doe" )
+--> 1, jane, doe
+
+table.insert( t, 2 )
+--> 1, jane, doe, 2	-- notice 'pos' parameter is ignored
+
+table.insert(t, 2, "miss")
+--> 1, miss, jane, doe, 2
 ``````

--- a/markdown/api/library/table/insert.markdown
+++ b/markdown/api/library/table/insert.markdown
@@ -24,13 +24,15 @@ Inserts a given value into a table. If a position is given, inserts the value be
 _[Table][api.type.Table]._ A table to which the new value will be added. When a table has an element inserted both the size of the array and the element indices are updated.
 
 ##### pos ~^(optional)^~
-_[Number][api.type.Number]._ The index of the table at which the new element will be inserted. The default value is the length of the table + 1 so that `table.insert(t,x)` inserts `x` at the end of table `t`. Note that it is faster to use the length operator: `t[#t + 1] = x`.
+_[Number][api.type.Number]._ The index of the table at which the new element will be inserted. The default value is the length of the table + 1 so that `table.insert(t,x)` inserts `x` at the end of table `t`.
 
 ##### value ~^(required)^~
 The new value to assign to be inserted into the table.
 
 ## Gotchas
-Please note that when 2 parameters are provided the optional parameter `pos` is ignored.
+When 2 parameters are provided, the optional parameter `pos` is ignored.
+
+Note that it is faster to use the length operator: `t[#t + 1] = x` when inserting new value to a table.
 
 ## Example
 

--- a/markdown/guide/physics/collisionDetection/index.markdown
+++ b/markdown/guide/physics/collisionDetection/index.markdown
@@ -94,6 +94,13 @@ Any collision event handler that returns `true` will stop further propagation of
 
 Collisions are reported between pairs of objects, and they can be detected either __locally__ on an object, using an object listener, or __globally__ using a runtime listener.
 
+<div class="guide-notebox-imp">
+<div class="notebox-title-imp">Important</div>
+
+When working with Corona [display&nbsp;groups][guide.graphics.group] and Box2D, it's important to remember that Box2D expects all physics objects to share a __global&nbsp;coordinate&nbsp;system__. Both grouped and ungrouped display objects will work well since they will share the internal coordinates of that group. However, unexpected results will occur if physical objects are added to different display groups and those groups are moved, scaled, or rotated independently of each other. As a general rule, do __not__ alter the position, scale, or rotation of display groups that contain physics objects. See [Physics Notes/Limitations][guide.physics.limitations]
+
+</div>
+
 ### Local Collision Handling
 
 Local collision handling is best utilized in a <nobr>one-to-many</nobr> collision scenario, for example one player object which may collide with multiple enemies, <nobr>power-ups</nobr>, etc. For local collision handling, each collision event includes a `self` table ID, representing the object itself, and `event.other` which contains the table ID of the other Corona display object involved in the collision. Because Corona display objects behave like Lua tables, you may freely add arbitrary data to these tables such as names, category designators, point values, or even stored functions, and then retrieve this data at collision time. For example, you may wish to store object names in an <nobr>easily-accessible</nobr> string format.

--- a/markdown/guide/physics/physicsSetup/index.markdown
+++ b/markdown/guide/physics/physicsSetup/index.markdown
@@ -70,9 +70,6 @@ physics.start( true )   -- Prevent all bodies from sleeping
 physics.start( false )  -- Default behavior; bodies may sleep after a few seconds
 ``````
 
-
-
-
 <a id="options"></a>
 
 ## Simulation Options

--- a/markdown/guide/physics/physicsSetup/index.markdown
+++ b/markdown/guide/physics/physicsSetup/index.markdown
@@ -51,6 +51,13 @@ physics.pause()
 physics.stop()
 ``````
 
+<div class="guide-notebox-imp">
+<div class="notebox-title-imp">Important</div>
+
+When working with Corona [display&nbsp;groups][guide.graphics.group] and Box2D, it's important to remember that Box2D expects all physics objects to share a __global&nbsp;coordinate&nbsp;system__. Both grouped and ungrouped display objects will work well since they will share the internal coordinates of that group. However, unexpected results will occur if physical objects are added to different display groups and those groups are moved, scaled, or rotated independently of each other. As a general rule, do __not__ alter the position, scale, or rotation of display groups that contain physics objects.
+
+</div>
+
 ### Sleeping Bodies
 
 By default, physical bodies not involved in a collision will "sleep" after a few seconds. This reduces performance overhead, but in some cases you may not want this behavior. This is particularly true in apps that use the accelerometer to effect changes in physics gravity — in this case, sleeping bodies will not respond to changes in the direction of gravity.
@@ -111,13 +118,6 @@ Physics data is displayed using colored vector graphics which reflect different 
 * green — static, non-moveable physics bodies
 * gray — a body that is "sleeping" due to lack of activity
 * light blue — physical joints (see the [Physics Joints][guide.physics.physicsJoints] guide)
-
-<div class="guide-notebox-imp">
-<div class="notebox-title-imp">Important</div>
-
-When working with Corona [display&nbsp;groups][guide.graphics.group] and Box2D, it's important to remember that Box2D expects all physics objects to share a __global&nbsp;coordinate&nbsp;system__. Both grouped and ungrouped display objects will work well since they will share the internal coordinates of that group. However, unexpected results will occur if physical objects are added to different display groups and those groups are moved, scaled, or rotated independently of each other. As a general rule, do __not__ alter the position, scale, or rotation of display groups that contain physics objects.
-
-</div>
 
 ### physics.setPositionIterations()
 

--- a/markdown/guide/physics/physicsSetup/index.markdown
+++ b/markdown/guide/physics/physicsSetup/index.markdown
@@ -54,7 +54,7 @@ physics.stop()
 <div class="guide-notebox-imp">
 <div class="notebox-title-imp">Important</div>
 
-When working with Corona [display&nbsp;groups][guide.graphics.group] and Box2D, it's important to remember that Box2D expects all physics objects to share a __global&nbsp;coordinate&nbsp;system__. Both grouped and ungrouped display objects will work well since they will share the internal coordinates of that group. However, unexpected results will occur if physical objects are added to different display groups and those groups are moved, scaled, or rotated independently of each other. As a general rule, do __not__ alter the position, scale, or rotation of display groups that contain physics objects.
+When working with Corona [display&nbsp;groups][guide.graphics.group] and Box2D, it's important to remember that Box2D expects all physics objects to share a __global&nbsp;coordinate&nbsp;system__. Both grouped and ungrouped display objects will work well since they will share the internal coordinates of that group. However, unexpected results will occur if physical objects are added to different display groups and those groups are moved, scaled, or rotated independently of each other. As a general rule, do __not__ alter the position, scale, or rotation of display groups that contain physics objects. See [Physics Notes/Limitations][guide.physics.limitations]
 
 </div>
 


### PR DESCRIPTION
Added a link to Physics Notes/Limitations at the end of working with display groups warning. There are a few tips at the notes that should be considered.

Moved working with display groups warning a bit higher to "Physics Setup" so developers would take that into account when starting to work with physics. It was under .setDrawMode() before. I thought that's more of a general physics advice than a certain function.

Added working with display groups warning to "Collision Handling". Thought that would be a good reminder and time saver at that point for developers who are struggling to make physics work.