### PR TITLE
Rebranding references, updating self-hosted plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Corona game engine documentation
+# Solar2D game engine documentation
 
 ![Deploy to GitHub pages](https://github.com/coronalabs/corona-docs/workflows/Deploy%20to%20GitHub%20pages/badge.svg)
 

--- a/bin/build.lua
+++ b/bin/build.lua
@@ -64,13 +64,13 @@ local images_dir = "../resources/images"
 local output_images_dir = html_dir .. "/images"
 
 -- strings to substitute throughout docs content (not headers or footers though)
-local title_prefix = "Corona Documentation"
+local title_prefix = "Solar2D Documentation"
 local default_rev_label = "Current Public Release (2018.3326)"
 local REV_LABEL = default_rev_label
 local DEFAULT_REV_URL = "https://coronalabs.com/links/docs/current-corona-sdk"
 local REV_URL_BASE = "https://developer.coronalabs.com/release/"  -- don't forget the trailing slash '/'
-local CORONA_CORE_PRODUCT = "Corona"
-local CORONA_NATIVE_PRODUCT = "Corona&nbsp;Native"
+local CORONA_CORE_PRODUCT = "Solar2D"
+local CORONA_NATIVE_PRODUCT = "Solar2D Native"
 
 require "lfs"
 require "pl.init"
@@ -384,7 +384,7 @@ for i=1,#markdown_files do
 	local path1 = normpath( abspath( markdown_files[i] ) )
 	local last_mod_date = lastmod( original_path )
 	local page_title = ""
-	local page_description = "Corona lets you build games/apps for all major platforms including iOS, Android, Kindle, Apple TV, Android TV, macOS, and Windows. Get the free toolset!"
+	local page_description = "Solar2D lets you build games/apps for all major platforms including iOS, Android, Kindle, Apple TV, Android TV, macOS, and Windows. Get the free toolset!"
 
 	-- only build the file if the last modified date is greater than last time build script was run
 	if is_clean_build or (not last_build_date) or (last_build_date:__lt( Date(last_mod_date) )) then

--- a/markdown/native/hostedPlugin.markdown
+++ b/markdown/native/hostedPlugin.markdown
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CORONA_NATIVE_PRODUCT users who have purchased a [Priority Plus](https://marketplace.coronalabs.com/support/priority-plus-support) support plan can enable plugins hosted on <nobr>3rd-party</nobr> servers. This allows you to create plugins for internal use and leverage the Corona&nbsp;Simulator's rapid build process with native code that you've written.
+Solar2D users can enable plugins hosted on third-party servers. This allows you to use third party plugins, as well as creating plugins for internal use and leveraging Solar2D's rapid build process with native code that you've written.
 
 
 ## Packaging and Hosting
@@ -20,11 +20,11 @@ Follow the [Plugins][native.plugin] guide to build your plugin, then package the
 Upload the resulting `.tgz` file to a web server that is accessible from the Internet. If necessary, `https://` and basic authentication are supported for security and access control.
 
 
-## Corona Simulator and Builds
+## Solar2D Simulator and Builds
 
 ### Running Plugins in the Simulator
 
-The Corona Simulator only accesses hosted plugins for device builds. When it comes to running these plugins in the Simulator, you must install these plugins locally by placing the plugin file in the following directory:
+Solar2D Simulator only accesses hosted plugins for device builds. When it comes to running these plugins in the Simulator, you must install these plugins locally by placing the plugin file in the following directory:
 
 	~/Library/Application Support/Corona/Simulator/Plugins/
 
@@ -33,17 +33,17 @@ This file should match the name used as the key in the `plugins` table, for exam
 
 ### Device Builds/Settings
 
-In order to use hosted plugins with your Corona project, the following changes to `build.settings` must be made:
+In order to use hosted plugins with your Solar2D project, the following changes to `build.settings` must be made:
 
-1. For each __device__ platform, you must tell Corona the URL from which to fetch the plugin `.tgz` file.
+1. For each __device__ platform, you must tell Solar2D the URL from which to fetch the plugin `.tgz` file.
 
     In the `supportedPlatforms` table for the plugin, each platform property key's value should contain the URL pointing to the `.tgz` plugin file.
 
-2. For each __Simulator__ platform, you must tell Corona __not__ to attempt download of a `.tgz` file.
+2. For each __Simulator__ platform, you must tell Solar2D __not__ to attempt download of a `.tgz` file.
 
     In the `supportedPlatforms` table for the plugin, the `macos` and `win32` key values should be `false`.
 
-    If you wish to use the plugin in the Corona Simulator, you must install the plugin locally as noted above.
+    If you wish to use the plugin in the Solar2D Simulator, you must install the plugin locally as noted above.
 
 Here is an example of including a hosted plugin within `build.settings`:
 
@@ -72,6 +72,6 @@ settings =
 
 * The maximum __compressed__ size for the `.tgz` file is 25&nbsp;MB. The maximum __uncompressed__ size for the `.tgz` file is 50&nbsp;MB.
 
-* The Corona Simulator will throw an error on launch/relaunch saying that the plugin couldn't be downloaded. This message is safe to ignore.
+* Solar2D Simulator will throw an error on launch/relaunch saying that the plugin couldn't be downloaded. This message is safe to ignore.
 
 </div>

--- a/markdown/native/hostedPlugin.markdown
+++ b/markdown/native/hostedPlugin.markdown
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CORONA_NATIVE_PRODUCT users can enable plugins hosted on third-party servers. This allows you to use third party plugins, as well as creating plugins for internal use and leveraging Solar2D's rapid build process with native code that you've written.
+CORONA_NATIVE_PRODUCT users can enable plugins hosted on third-party servers. This allows you to use third party plugins as well as creating plugins for internal use and leveraging Solar2D's rapid build process with native code that you've written.
 
 
 ## Packaging and Hosting

--- a/markdown/native/hostedPlugin.markdown
+++ b/markdown/native/hostedPlugin.markdown
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Solar2D users can enable plugins hosted on third-party servers. This allows you to use third party plugins, as well as creating plugins for internal use and leveraging Solar2D's rapid build process with native code that you've written.
+CORONA_NATIVE_PRODUCT users can enable plugins hosted on third-party servers. This allows you to use third party plugins, as well as creating plugins for internal use and leveraging Solar2D's rapid build process with native code that you've written.
 
 
 ## Packaging and Hosting

--- a/markdown/native/index.markdown
+++ b/markdown/native/index.markdown
@@ -2,7 +2,7 @@
 
 CORONA_NATIVE_PRODUCT lets you extend CORONA_CORE_PRODUCT beyond the functionality provided by the CORONA_CORE_PRODUCT Lua&nbsp;APIs \([reference][api]\). For instance, you can use native languages like <nobr>Objective-C</nobr> or Java and pass information between the native code and Lua code. You can also [create plugins][native.plugin] that make it even easier to get native platform features into apps built with CORONA_CORE_PRODUCT.
 
-If you don't need to include custom native code in your app, the Corona&nbsp;Simulator is the best tool to use. Get started [here][guide.programming.01].
+If you don't need to include custom native code in your app, Solar2D Simulator is the best tool to use. Get started [here][guide.programming.01].
 
 
 ## System Requirements
@@ -35,7 +35,7 @@ To get started with CORONA_NATIVE_PRODUCT for Android, please proceed to [CORONA
 
 ## Plugin Development
 
-Plugins let you extend Corona functionality, leveraging <nobr>pre-built</nobr> components. You can create plugins that can be <nobr>re-used</nobr> across projects and submit a plugin for availability in the [Corona Marketplace](https://marketplace.coronalabs.com).
+Plugins let you extend Solar2D functionality, leveraging <nobr>pre-built</nobr> components. You can create plugins that can be <nobr>re-used</nobr> across projects and submit a plugin for availability in the [Corona Marketplace](https://marketplace.coronalabs.com).
 
 Learn more in our [Plugins][native.plugin] guide or in our [Plugin Submission Guide][native.plugin.submission].
 
@@ -44,4 +44,4 @@ Learn more in our [Plugins][native.plugin] guide or in our [Plugin Submission Gu
 
 ## Self-Hosted Plugins
 
-CORONA_NATIVE_PRODUCT users who have purchased a [Priority Plus](https://marketplace.coronalabs.com/support/priority-plus-support) support plan can enable plugins hosted on <nobr>3rd-party</nobr> servers. Learn more in our [Self-Hosted Plugins][native.hostedPlugin] guide.
+CORONA_NATIVE_PRODUCT users can enable plugins hosted on third-party servers. Learn more in our [Self-Hosted Plugins][native.hostedPlugin] guide.


### PR DESCRIPTION
Changed core product and native product variables in build.lua so all references to that variable would be changed in the docs. There are still many places that doesn't use those variables so more work is needed.

There is a reference to Corona Marketplace in [native documentation](https://docs.coronalabs.com/native/index.html#plugin-development). I know there are alternatives but not sure if I should point them out at this point. Please let me know if you want this link changed.

In self-hosted plugins page, I was not sure if I should change it to Solar2D core product instead of native so I kept it that way. Also, in the same page [Running Plugins in the Simulator](https://docs.coronalabs.com/native/hostedPlugin.html#running-plugins-in-the-simulator)  only references macOS. If it works on Windows, it would be a good idea to add instructions for that too. I have no experience in that so if you could send me the instructions, I could try to update the docs to reflect that change.