### PR TITLE
Fixes for Windows install page

### DIFF
--- a/bin/build.lua
+++ b/bin/build.lua
@@ -65,7 +65,7 @@ local output_images_dir = html_dir .. "/images"
 
 -- strings to substitute throughout docs content (not headers or footers though)
 local title_prefix = "Solar2D Documentation"
-local default_rev_label = "Current Release (2020.3601)"
+local default_rev_label = "Release 2020.3601"
 local REV_LABEL = default_rev_label
 local DEFAULT_REV_URL = "https://github.com/coronalabs/corona/releases"
 local REV_URL_BASE = "https://github.com/coronalabs/corona/releases/"  -- don't forget the trailing slash '/'

--- a/markdown/guide/start/installWin/index.markdown
+++ b/markdown/guide/start/installWin/index.markdown
@@ -98,7 +98,7 @@ The CORONA_CORE_PRODUCT development environment consists of two aspects: the __S
 
 * The __Solar2D Simulator__ is a visual representation and test environment for your app. What you see in the Simulator is generally what your app will look like — and how it will function — when deployed to an actual device. CORONA_CORE_PRODUCT Simulator is an essential tool because it allows you to view changes to your code instantly in an active, responsive environment that closely mimics the device.
 
-* The __Solar2D Console__ is where you can view diagnostic messages about what's happening in your program. This window is automatically displayed when you launch the CORONA_CORE_PRODUCT Simulator.
+* The __Solar2D Simulator Console__ is where you can view diagnostic messages about what's happening in your program. This window is automatically displayed when you launch the CORONA_CORE_PRODUCT Simulator.
 
 
 

--- a/markdown/guide/start/installWin/index.markdown
+++ b/markdown/guide/start/installWin/index.markdown
@@ -28,7 +28,7 @@ You do not need to install the Android SDK to use CORONA_CORE_PRODUCT. However, 
 </div>
 </div>
 
-We'll assume you've already downloaded [CORONA_CORE_PRODUCT](https://github.com/coronalabs/corona/releases). Now, double click the `.msi` installer file and follow the steps in the installation wizard.
+We'll assume you've already downloaded [CORONA_CORE_PRODUCT](REVISION_URL). Now, double click the `.msi` installer file and follow the steps in the installation wizard.
 
 
 <a id="jdk"></a>

--- a/markdown/guide/start/installWin/index.markdown
+++ b/markdown/guide/start/installWin/index.markdown
@@ -28,7 +28,7 @@ You do not need to install the Android SDK to use CORONA_CORE_PRODUCT. However, 
 </div>
 </div>
 
-We'll assume you've already downloaded [CORONA_CORE_PRODUCT](DEFAULT_REV_URL). Now, double click the `.msi` installer file and follow the steps in the installation wizard.
+We'll assume you've already downloaded [CORONA_CORE_PRODUCT](https://github.com/coronalabs/corona/releases). Now, double click the `.msi` installer file and follow the steps in the installation wizard.
 
 
 <a id="jdk"></a>
@@ -94,11 +94,11 @@ Editor																Add-On Package
 
 ## Development Environment
 
-The CORONA_CORE_PRODUCT development environment consists of two aspects: the __CORONA_CORE_PRODUCT Simulator__ and the __CORONA_CORE_PRODUCT Console__ window.
+The CORONA_CORE_PRODUCT development environment consists of two aspects: the __Solar2D Simulator__ and the __Solar2D Console__ window.
 
-* The __CORONA_CORE_PRODUCT Simulator__ is a visual representation and test environment for your app. What you see in the Simulator is generally what your app will look like — and how it will function — when deployed to an actual device. CORONA_CORE_PRODUCT Simulator is an essential tool because it allows you to view changes to your code instantly in an active, responsive environment that closely mimics the device.
+* The __Solar2D Simulator__ is a visual representation and test environment for your app. What you see in the Simulator is generally what your app will look like — and how it will function — when deployed to an actual device. CORONA_CORE_PRODUCT Simulator is an essential tool because it allows you to view changes to your code instantly in an active, responsive environment that closely mimics the device.
 
-* The __CORONA_CORE_PRODUCT Simulator Console__ is where you can view diagnostic messages about what's happening in your program. This window is automatically displayed when you launch the CORONA_CORE_PRODUCT Simulator.
+* The __Solar2D Console__ is where you can view diagnostic messages about what's happening in your program. This window is automatically displayed when you launch the CORONA_CORE_PRODUCT Simulator.
 
 
 


### PR DESCRIPTION
Changed revision label wording. "Current Release" string which I added with the earlier request didn't make sense when I took a second look at it. This one is better.

Changed download link constant to REVISION_URL. This should make it work but if it won't, I'll make another request to fix it with a simple string.

Removed usage of constants for **bold** stylized items. It seems that when a text is stylized, build.lua constant is ignored.

@Shchvova the last pull request seems to have broken some stuff, sorry about that. This is a fix to make it work. I'd suggest merging it as soon as possible.