### PR TITLE
Fix for legal disclaimer

### DIFF
--- a/markdown/guide/programming/intro/index.markdown
+++ b/markdown/guide/programming/intro/index.markdown
@@ -335,6 +335,7 @@ The most fun way to learn CORONA_CORE_PRODUCT is to [create a simple game][guide
 [Chapter 1 &mdash; Creating a project][guide.programming.01] __&rang;__
 
 </div>
+<div class="clear"></div>
 
 
 <!--- LEGAL -->


### PR DESCRIPTION
Legal disclaimer was overlapping the whole page. Hopefully, this will fix the issue caused by the latest commit. 