### PR TITLE
Added references to source code

### DIFF
--- a/markdown/api/library/composer/index.markdown
+++ b/markdown/api/library/composer/index.markdown
@@ -143,4 +143,4 @@ return scene
 
 * [View on GitHub](https://github.com/coronalabs/framework-composer)
 
-If you want to add or modify scene transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add/modify scene transition effects or extend functionality, download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/composer/index.markdown
+++ b/markdown/api/library/composer/index.markdown
@@ -138,3 +138,9 @@ scene:addEventListener( "destroy", scene )
 
 return scene
 ``````
+
+## Source
+
+* [View on GitHub](https://github.com/coronalabs/framework-composer)
+
+If you want to add or modify scene transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/easing/index.markdown
+++ b/markdown/api/library/easing/index.markdown
@@ -194,3 +194,9 @@ local circle = display.newCircle( 100, 100, 40 )
 circle:setFillColor( 0, 0, 1 )
 transition.to( circle, { time=400, y=200, transition=easing.inExpo } )
 ``````
+
+## Source
+
+* [View on GitHub](https://github.com/coronalabs/framework-easing)
+
+If you want to add, modify or extend functionality, download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -31,4 +31,4 @@ Timer functions allow calling a function some time in the future rather than imm
 
 * [View on GitHub](https://github.com/coronalabs/framework-timer)
 
-If you want to add new functionality or modify existing methods, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add new functionality or modify existing methods, download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -31,4 +31,4 @@ Timer functions allow calling a function some time in the future rather than imm
 
 * [View on GitHub](https://github.com/coronalabs/framework-timer)
 
-If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add new functionality or modify existing methods, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -26,3 +26,9 @@ Timer functions allow calling a function some time in the future rather than imm
 ## Properties
 
 #### [timer.allowIterationsWithinFrame][api.library.timer.allowIterationsWithinFrame]
+
+## Source
+
+* [View source code on GitHub](https://github.com/coronalabs/framework-timer)
+
+If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -29,6 +29,6 @@ Timer functions allow calling a function some time in the future rather than imm
 
 ## Source
 
-* [View source code on GitHub](https://github.com/coronalabs/framework-timer)
+* [View on GitHub](https://github.com/coronalabs/framework-timer)
 
 If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/performWithDelay.markdown
+++ b/markdown/api/library/timer/performWithDelay.markdown
@@ -97,9 +97,3 @@ local tm = timer.performWithDelay( 1000, onTimer )
 -- Assign a table of parameters to the "tm" handle
 tm.params = { myParam1 = "Parameter1", myParam2 = "Parameter2" }
 ``````
-
-## Extras
-
-* [Source code](https://github.com/coronalabs/framework-timer)
-
-If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/performWithDelay.markdown
+++ b/markdown/api/library/timer/performWithDelay.markdown
@@ -102,4 +102,4 @@ tm.params = { myParam1 = "Parameter1", myParam2 = "Parameter2" }
 
 * [Source code](https://github.com/coronalabs/framework-timer)
 
-If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [External Modules in CORONA_CORE_PRODUCT][tutorial.basics.externalModules]).
+If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/timer/performWithDelay.markdown
+++ b/markdown/api/library/timer/performWithDelay.markdown
@@ -20,10 +20,9 @@ Calls a specified function after a delay. This function returns a [table][api.ty
 
 ## Gotchas
 
-**WARNING**
-*This part might be outdated because timers __do__ get automatically paused on applicationSuspend and resumed on applicationResume.*
+Timers will be automatically paused when the application is suspended and resume when the application is resumed. However, to avoid unwanted behaviours, it is strongly advised to handle your timers __manually__. Thus, if you have running timers that are not paused and resumed (in&nbsp;code) upon suspension of the app, you should handle this task by calling [timer.pause()][api.library.timer.pause] and [timer.resume()][api.library.timer.resume] on all applicable timers.
 
-Timers run on system time. If the app is suspended, running timers will __not__ be automatically paused, meaning that when the app is resumed, all timers that would have completed/triggered during the suspended period will trigger immediately. Thus, if you have running timers that are not paused (in&nbsp;code) upon suspension of the app, you should handle this task by calling [timer.pause()][api.library.timer.pause] on all applicable timers.
+Timers will __not__ be automatically cancelled when changing a scene. Thus, if you have running timers that are not cancelled, you must handle this __manually__ by calling [timer.cancel()][api.library.timer.cancel] on all applicable timers.
 
 
 ## Syntax
@@ -98,3 +97,9 @@ local tm = timer.performWithDelay( 1000, onTimer )
 -- Assign a table of parameters to the "tm" handle
 tm.params = { myParam1 = "Parameter1", myParam2 = "Parameter2" }
 ``````
+
+## Extras
+
+* [Source code](https://github.com/coronalabs/framework-timer)
+
+If you want to add new functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [External Modules in CORONA_CORE_PRODUCT][tutorial.basics.externalModules]).

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -52,3 +52,9 @@ The transition library provides functions and methods to transition/tween displa
 #### [transition.scaleBy()][api.library.transition.scaleBy]
 
 #### [transition.scaleTo()][api.library.transition.scaleTo]
+
+## Source
+
+* [View source code on GitHub](https://github.com/coronalabs/framework-transition)
+
+If you want to add new transition effects, extend functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -57,4 +57,4 @@ The transition library provides functions and methods to transition/tween displa
 
 * [View on GitHub](https://github.com/coronalabs/framework-transition)
 
-If you want to add or modify transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add/modify transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -57,4 +57,4 @@ The transition library provides functions and methods to transition/tween displa
 
 * [View on GitHub](https://github.com/coronalabs/framework-transition)
 
-If you want to add new transition effects, extend functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add or modify transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -57,4 +57,4 @@ The transition library provides functions and methods to transition/tween displa
 
 * [View on GitHub](https://github.com/coronalabs/framework-transition)
 
-If you want to add/modify transition effects or extend functionality, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add/modify transition effects or extend functionality, download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -55,6 +55,6 @@ The transition library provides functions and methods to transition/tween displa
 
 ## Source
 
-* [View source code on GitHub](https://github.com/coronalabs/framework-transition)
+* [View on GitHub](https://github.com/coronalabs/framework-transition)
 
 If you want to add new transition effects, extend functionality or modify existing ones, you can download or fork the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/widget/index.markdown
+++ b/markdown/api/library/widget/index.markdown
@@ -37,4 +37,4 @@
 
 * [View on GitHub](https://github.com/coronalabs/framework-widget)
 
-If you want to add new widgets or modify existing ones, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).
+If you want to add new widgets, modify existing ones or extend functionality, download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).

--- a/markdown/api/library/widget/index.markdown
+++ b/markdown/api/library/widget/index.markdown
@@ -32,3 +32,9 @@
 #### [widget.newTableView()][api.library.widget.newTableView]
 
 #### [widget.setTheme()][api.library.widget.setTheme]
+
+## Source
+
+* [View on GitHub](https://github.com/coronalabs/framework-widget)
+
+If you want to add new widgets or modify existing ones, you can download the source code from GitHub and include in your project(See [Using External Modules][tutorial.basics.externalModules]).


### PR DESCRIPTION
Added references to the source codes of `composer.*`, `easing.*`, `timer.*`, `transition.*` and `widget.*` libraries.

Moved source code reference of `timer` to its index page.