### PR TITLE
Update timer and transition docs to reflect new features

### DIFF
--- a/markdown/api/library/timer/allowIterationsWithinFrame.markdown
+++ b/markdown/api/library/timer/allowIterationsWithinFrame.markdown
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Changes the behavior of the timer object to provide events as soon as possible instead of waiting until the next frame to execute. The default behavior is `false` meaning that timers fire on frame intervals. Setting this to `true` will enable the events to arrive as soon as possible.
+Changes the behavior of the timer object to provide events as soon as possible instead of waiting until the next frame to execute. The default behavior is `false`, meaning that timers fire on frame intervals. Setting this to `true` will enable the events to arrive as soon as possible.
 
 ## Syntax
 

--- a/markdown/api/library/timer/cancel.markdown
+++ b/markdown/api/library/timer/cancel.markdown
@@ -12,7 +12,7 @@
 
 ## Overview
 
-Cancels a timer operation initiated with [timer.performWithDelay()][api.library.timer.performWithDelay].
+Cancels a specific timer or all timers with the same tag that were initiated with [timer.performWithDelay()][api.library.timer.performWithDelay].
 
 <!---
 
@@ -22,12 +22,35 @@ This function returns two numbers: time remaining ( and number of iterations tha
 
 ## Syntax
 
-	timer.cancel( timerID )
+	timer.cancel( whatToCancel )
 
-##### timerID ~^(required)^~
-_[Object][api.type.Object]._ Handle returned by the call to [timer.performWithDelay()][api.library.timer.performWithDelay].
+##### whatToCancel ~^(required)^~
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
 
 ## Example
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener )  -- wait 2 seconds
+
+-- sometime later...
+timer.cancel( timer1 )
+`````
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener, "red" )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener, "blue" )  -- wait 3 seconds
+
+-- sometime later...
+timer.cancel( "red" )
+`````
 
 `````lua
 local t = {}

--- a/markdown/api/library/timer/cancelAll.markdown
+++ b/markdown/api/library/timer/cancelAll.markdown
@@ -1,0 +1,40 @@
+
+# timer.cancelAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [timer.*][api.library.timer]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          timer, delay, cancel
+> __See also__          [timer.cancel()][api.library.timer.cancel]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Cancels all timer operations initiated with [timer.performWithDelay()][api.library.timer.performWithDelay].
+
+<!---
+
+This function doesn't return any values.
+
+-->
+
+## Syntax
+
+	timer.cancelAll()
+
+
+## Example
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener )  -- wait 3 seconds
+
+-- sometime later...
+timer.cancelAll()
+`````

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -17,11 +17,17 @@ Timer functions allow calling a function some time in the future rather than imm
 
 #### [timer.cancel()][api.library.timer.cancel]
 
+#### [timer.cancelAll()][api.library.timer.cancel]
+
 #### [timer.pause()][api.library.timer.pause]
+
+#### [timer.pause()][api.library.timer.pauseAll]
 
 #### [timer.performWithDelay()][api.library.timer.performWithDelay]
 
 #### [timer.resume()][api.library.timer.resume]
+
+#### [timer.resume()][api.library.timer.resumeAll]
 
 ## Properties
 

--- a/markdown/api/library/timer/pause.markdown
+++ b/markdown/api/library/timer/pause.markdown
@@ -13,14 +13,16 @@
 
 ## Overview
 
-Pauses a timer started with [timer.performWithDelay()][api.library.timer.performWithDelay]. It returns a [number][api.type.Number] that represents the amount of time remaining, in milliseconds.
+Pauses a specific timer or all timers with the same tag that were started with [timer.performWithDelay()][api.library.timer.performWithDelay].
+
+If a specific timer is paused, then the function returns a [number][api.type.Number] that represents the amount of time remaining, in milliseconds.
 
 ## Syntax
 
-	timer.pause( timerId )
+	timer.pause( whatToPause )
 
-##### timerId ~^(required)^~
-_[Table][api.type.Table]._ The timer ID from [timer.performWithDelay()][api.library.timer.performWithDelay].
+##### whatToPause ~^(required)^~
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
 
 ## Example
 
@@ -34,4 +36,16 @@ timer1 = timer.performWithDelay( 2000, listener )  -- wait 2 seconds
 -- sometime later...
 local result = timer.pause( timer1 )
 print( "Time remaining is " .. result )
+`````
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+
+timer1 = timer.performWithDelay( 2000, listener, "red" )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener, "blue" )  -- wait 3 seconds
+
+-- sometime later...
+timer.pause( "red" )
 `````

--- a/markdown/api/library/timer/pauseAll.markdown
+++ b/markdown/api/library/timer/pauseAll.markdown
@@ -1,0 +1,34 @@
+
+# timer.pauseAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [timer.*][api.library.timer]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          timer, pause, resume
+> __See also__          [timer.pause()][api.library.timer.pause]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Pauses all timers started with [timer.performWithDelay()][api.library.timer.performWithDelay].
+
+## Syntax
+
+	timer.pauseAll( timerId )
+
+
+## Example
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener )  -- wait 3 seconds
+
+-- sometime later...
+timer.pauseAll()
+`````

--- a/markdown/api/library/timer/performWithDelay.markdown
+++ b/markdown/api/library/timer/performWithDelay.markdown
@@ -27,7 +27,7 @@ Timers will __not__ be automatically cancelled when changing a scene. Thus, if y
 
 ## Syntax
 
-	timer.performWithDelay( delay, listener [, iterations] )
+	timer.performWithDelay( delay, listener [, iterations] [, tag] )
 
 ##### delay ~^(required)^~
 _[Number][api.type.Number]._ The delay in milliseconds, for example, `1000` = 1 second. Note that timers cannot execute faster than the runtime framerate of the app. For example, if the framerate of the app is `60` frames per second, as defined in the `config.lua` file \([guide][guide.basics.configSettings]\), the shortest delay for a timer is approximately `16.667` milliseconds <nobr>(`1000`/`60` = ~`16.667`)</nobr>.
@@ -36,7 +36,10 @@ _[Number][api.type.Number]._ The delay in milliseconds, for example, `1000` = 1 
 _[Listener][api.type.Listener]._ The listener to invoke after the delay. This may be either a function listener or a table listener. If a table listener, it must have a timer method because timer events are sent to the listener.
 
 ##### iterations ~^(optional)^~
-_[Number][api.type.Number]._ Optionally specifies the number of times `listener` is to be invoked. By default, it is `1`; pass `0` or `-1` if you want the timer to loop forever.
+_[Number][api.type.Number]._ Optionally specify the number of times `listener` is to be invoked. By default, it is `1`; pass `0` or `-1` if you want the timer to loop forever.
+
+##### tag ~^(optional)^~
+_[String][api.type.String]._ Optionally assign a `tag` to the timer. You can pause, resume or cancel all timers that share the same `tag` with a single function call.
 
 
 ## Examples

--- a/markdown/api/library/timer/resume.markdown
+++ b/markdown/api/library/timer/resume.markdown
@@ -13,14 +13,16 @@
 
 ## Overview
 
-Resumes a timer that was paused with [timer.pause()][api.library.timer.pause]. It returns a [number][api.type.Number] that represents the amount of time remaining in the timer.
+Resumes a specific timer or all timers with the same tag that were paused with [timer.pause()][api.library.timer.pause].
+
+If a specific timer is resumed, then the function returns a [number][api.type.Number] that represents the amount of time remaining in the timer.
 
 ## Syntax
 
-	timer.resume( timerId )
+	timer.resume( whatToResume )
 
-##### timerId ~^(required)^~
-_[Object][api.type.Object]._ The timer ID from [timer.performWithDelay()][api.library.timer.performWithDelay].
+##### whatToResume ~^(required)^~
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
 
 
 ## Example
@@ -39,4 +41,19 @@ print( "Time remaining is " .. pauseTime )
 -- sometime later...
 local resumeTime = timer.resume( timer1 )
 print( "Resume time is " .. resumeTime )
+`````
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener, "red" )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener, "blue" )  -- wait 3 seconds
+
+-- sometime later...
+timer.pause( "red" )
+
+-- sometime later...
+timer.resume( "red" )
 `````

--- a/markdown/api/library/timer/resumeAll.markdown
+++ b/markdown/api/library/timer/resumeAll.markdown
@@ -1,0 +1,37 @@
+
+# timer.resumeAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [timer.*][api.library.timer]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          timer, resume, pause
+> __See also__          [timer.resume()][api.library.timer.resume]
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Resumes all timers that were paused with [timer.pause()][api.library.timer.pause].
+
+## Syntax
+
+	timer.resumeAll()
+
+
+## Example
+
+`````lua
+local function listener( event )
+    print( "listener called" )
+end
+ 
+timer1 = timer.performWithDelay( 2000, listener )  -- wait 2 seconds
+timer2 = timer.performWithDelay( 3000, listener )  -- wait 3 seconds
+
+-- sometime later...
+timer.pauseAll()
+
+-- sometime later...
+timer.resumeAll()
+`````

--- a/markdown/api/library/transition/cancel.markdown
+++ b/markdown/api/library/transition/cancel.markdown
@@ -40,7 +40,7 @@ _[String][api.type.String]._ The tag name; all transitions with this tag will be
 ## Examples
 
 ``````lua
--- cancel all running transitions
+-- cancel all running (and paused) transitions
 
 local transition1 = transition.to( currentTarget, { time=400, y=y+100, iterations=5, tag="transTag" } )
 local transition2 = transition.to( otherTarget, { time=200, y=y-200, tag="transTag" } )

--- a/markdown/api/library/transition/cancelAll.markdown
+++ b/markdown/api/library/transition/cancelAll.markdown
@@ -1,0 +1,33 @@
+# transition.cancelAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [transition.*][api.library.transition]
+> __Return value__      none
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          easing, animation, transition, tween, interpolation
+> __See also__			[Transitions][guide.media.transitionLib] _(guide)_
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+The `transition.cancelAll()` function cancels all running and paused transitions.
+
+
+## Syntax
+
+	transition.cancelAll()
+
+
+## Examples
+
+``````lua
+-- cancel all running (and paused) transitions
+
+local transition1 = transition.to( currentTarget, { time=400, y=y+100, iterations=5, tag="transTag" } )
+local transition2 = transition.to( otherTarget, { time=200, y=y-200, tag="transTag" } )
+
+-- later, cancel all running transitions
+transition.cancelAll()
+``````

--- a/markdown/api/library/transition/ignoreEmptyReference.markdown
+++ b/markdown/api/library/transition/ignoreEmptyReference.markdown
@@ -1,0 +1,25 @@
+# transition.ignoreEmptyReference
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Boolean][api.type.Boolean]
+> __Library__           [transition.*][api.library.transition]
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          transition, ignoreEmptyReference
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+Changes the default behavior of the [transition.pause()][api.library.transition.pause], [transition.resume()][api.library.transition.resume] and [transition.cancel()][api.library.transition.cancel] functions so that if `nil` or no argument is passed into these functions, they will be ignored and nothing will happen. The default behavior is `false`, which means that passing `nil` or no argument into these three functions will pause, resume or cancel all functions.
+
+You can always use [transition.pauseAll()][api.library.transition.pauseAll], [transition.resumeAll()][api.library.transition.resumeAll] and [transition.cancelAll()][api.library.transition.cancelAll] to control all transitions.
+
+## Syntax
+
+	transition.ignoreEmptyReference
+
+## Example
+
+`````lua
+transition.ignoreEmptyReference = true
+`````

--- a/markdown/api/library/transition/index.markdown
+++ b/markdown/api/library/transition/index.markdown
@@ -27,11 +27,17 @@ The transition library provides functions and methods to transition/tween displa
 
 #### [transition.cancel()][api.library.transition.cancel]
 
+#### [transition.cancelAll()][api.library.transition.cancelAll]
+
 #### [transition.from()][api.library.transition.from]
 
 #### [transition.pause()][api.library.transition.pause]
 
+#### [transition.pauseAll()][api.library.transition.pauseAll]
+
 #### [transition.resume()][api.library.transition.resume]
+
+#### [transition.resumeAll()][api.library.transition.resumeAll]
 
 #### [transition.to()][api.library.transition.to]
 
@@ -52,6 +58,10 @@ The transition library provides functions and methods to transition/tween displa
 #### [transition.scaleBy()][api.library.transition.scaleBy]
 
 #### [transition.scaleTo()][api.library.transition.scaleTo]
+
+## Properties
+
+#### [transition.ignoreEmptyReference][api.library.transition.ignoreEmptyReference]
 
 ## Source
 

--- a/markdown/api/library/transition/pauseAll.markdown
+++ b/markdown/api/library/transition/pauseAll.markdown
@@ -1,0 +1,33 @@
+# transition.pauseAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [transition.*][api.library.transition]
+> __Return value__      none
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          easing, animation, transition, tween, interpolation
+> __See also__			[Transitions][guide.media.transitionLib] _(guide)_
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+The `transition.pauseAll()` function pauses all running transitions.
+
+
+## Syntax
+
+	transition.pauseAll()
+
+
+## Examples
+
+``````lua
+-- pause all running transitions
+
+local transition1 = transition.to( currentTarget, { time=400, y=y+100, iterations=5, tag="transTag" } )
+local transition2 = transition.to( otherTarget, { time=200, y=y-200, tag="transTag" } )
+
+-- later, pause all running transitions
+transition.pauseAll()
+``````

--- a/markdown/api/library/transition/resumeAll.markdown
+++ b/markdown/api/library/transition/resumeAll.markdown
@@ -1,0 +1,36 @@
+# transition.resumeAll()
+
+> --------------------- ------------------------------------------------------------------------------------------
+> __Type__              [Function][api.type.Function]
+> __Library__           [transition.*][api.library.transition]
+> __Return value__      none
+> __Revision__          [REVISION_LABEL](REVISION_URL)
+> __Keywords__          easing, animation, transition, tween, interpolation
+> __See also__			[Transitions][guide.media.transitionLib] _(guide)_
+> --------------------- ------------------------------------------------------------------------------------------
+
+
+## Overview
+
+The `transition.resumeAll()` function resumes all paused transitions.
+
+
+## Syntax
+
+	transition.resumeAll()
+
+
+## Examples
+
+``````lua
+-- resume all paused transitions
+
+local transition1 = transition.to( currentTarget, { time=400, y=y+100, iterations=5, tag="transTag" } )
+local transition2 = transition.to( otherTarget, { time=200, y=y-200, tag="transTag" } )
+
+-- at some point, pause all running transitions
+transition.pauseAll()
+
+-- later, resume all paused transitions
+transition.resumeAll()
+``````

--- a/markdown/guide/media/transitionLib/index.markdown
+++ b/markdown/guide/media/transitionLib/index.markdown
@@ -222,7 +222,9 @@ All transitions — standard and sequenced — can be paused, resumed, or cancel
 
 ### Pause
 
-Transitions can be paused with the [transition.pause()][api.library.transition.pause] function. This only effects transitions that are running.
+Transitions can be paused with the [transition.pause()][api.library.transition.pause] and [transition.pauseAll()][api.library.transition.pauseAll] functions. These only affect transitions that are running.
+
+With the [transition.pause()][api.library.transition.pause] function, you can control which specific transitions to pause by what parameter you use.
 
 <div class="inner-table">
 
@@ -238,7 +240,9 @@ tag name (string)		Pauses all running transitions sharing the same tag name.
 
 ### Resume
 
-Transitions can be resumed with the [transition.resume()][api.library.transition.resume] function. This only effects transitions that are paused.
+Transitions can be resumed with the [transition.resume()][api.library.transition.resume] and [transition.resumeAll()][api.library.transition.resumeAll] functions. These only affect transitions that are paused.
+
+With the [transition.resume()][api.library.transition.resume] function, you can control which specific transitions to resume by what parameter you use.
 
 <div class="inner-table">
 
@@ -254,7 +258,9 @@ tag name (string)		Resumes all paused transitions sharing the same tag name.
 
 ### Cancel
 
-Transitions can be cancelled with the [transition.cancel()][api.library.transition.cancel] function. Note that the transition(s) will stop in place — they will not revert to the beginning state or skip to the ending state. This function only effects transitions that are currently running or paused.
+Transitions can be cancelled with the [transition.cancel()][api.library.transition.cancel] and [transition.cancelAll()][api.library.transition.cancelAll] functions. Note that the transition(s) will stop in place — they will not revert to their beginning state or skip to the end state. These functions only effects transitions that are currently running or paused.
+
+With the [transition.cancel()][api.library.transition.cancel] function, you can control which specific transitions to cancel by what parameter you use.
 
 <div class="inner-table">
 
@@ -265,6 +271,19 @@ transition reference	Cancels a specific running/paused transition.
 object reference		Cancels all running/paused transitions on a specific object.
 tag name (string)		Cancels all running/paused transitions sharing the same tag name.
 ----------------------	--------------------------
+
+</div>
+
+<div class="guide-notebox-imp">
+<div class="notebox-title-imp">Important</div>
+
+If you accidentally pass a reference to a display object into [transition.pause()][api.library.transition.pause], [transition.resume()][api.library.transition.resume] or [transition.cancel()][api.library.transition.cancel] after the display object has already been removed, then the argument will be `nil`. This is the same passing no argument into the function, which will result in all transitions being paused, resumed or cancelled (depending on the function).
+
+In order to avoid this default behaviour, you can include the following line of code in your project after requiring the transition library:
+``````lua
+transition.ignoreEmptyReference = true
+``````
+If set `transition.ignoreEmptyReference` to `true` (default is `false`), then passing `nil` or no argument into these three functions will be ignored and nothing will happen. You can always use [transition.pauseAll()][api.library.transition.pauseAll], [transition.resumeAll()][api.library.transition.resumeAll] and [transition.cancelAll()][api.library.transition.cancelAll] to control all transitions.
 
 </div>
 


### PR DESCRIPTION
Update existing documentation and add new documentation for timer and transition libraries to explain the changes introduced in:

https://github.com/coronalabs/framework-timer/pull/2

and

https://github.com/coronalabs/framework-transition/pull/1