### PR TITLE
Min SDK 16 for FCM 20.2.3

### DIFF
--- a/markdown/guide/events/appNotification/index.markdown
+++ b/markdown/guide/events/appNotification/index.markdown
@@ -91,12 +91,28 @@ settings =
 	},
 }
 ``````
+Inside this `build.settings` file, also include the `minSdkVersion` of 16 or higher. For more info about setting minimum SDK version, [see this](https://docs.coronalabs.com/guide/distribution/advancedSettings/index.html)
+
+``````{ brush="lua" gutter="false" first-line="1" highlight="[5,6,7,8]" }
+settings =
+{
+    android =
+    {
+        minSdkVersion = "16",
+    },
+}
+``````
+
+
+
 
 Then, within the code module which uses notifications functions, simply `require()` the library as follows:
 
 ``````lua
 local notifications = require( "plugin.notifications.v2" )
 ``````
+
+
 
 <div class="guide-notebox-imp">
 <div class="notebox-title-imp">Important</div>


### PR DESCRIPTION
The latest build uses FCM 20.2.3 and requires SDK >16 (https://firebase.google.com/docs/cloud-messaging/android/client)

Error from build using default minSdkVersion of 15 
> Manifest merger failed : uses-sdk:minSdkVersion 15 cannot be smaller than version 16 declared in library [com.google.firebase:firebase-messaging:20.2.3] C:\Users\LK\.gradle\caches\transforms-2\files-2.1\e55f47a050ce7c1ecf1b888d9335de03\jetified-firebase-messaging-20.2.3\AndroidManifest.xml as the library might be using APIs not available in 15