### PR TITLE
Fix 2 incorrect link names & add notes about min Solar2D version

### DIFF
--- a/markdown/api/library/timer/cancel.markdown
+++ b/markdown/api/library/timer/cancel.markdown
@@ -25,7 +25,7 @@ This function returns two numbers: time remaining ( and number of iterations tha
 	timer.cancel( whatToCancel )
 
 ##### whatToCancel ~^(required)^~
-_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay]. Note: Using `tag` requires `Solar2D 2020.3611` or a newer build.
 
 ## Example
 

--- a/markdown/api/library/timer/cancelAll.markdown
+++ b/markdown/api/library/timer/cancelAll.markdown
@@ -14,6 +14,8 @@
 
 Cancels all timer operations initiated with [timer.performWithDelay()][api.library.timer.performWithDelay].
 
+Note: Using [timer.cancelAll()][api.library.timer.cancelAll] requires `Solar2D 2020.3611` or a newer build.
+
 <!---
 
 This function doesn't return any values.

--- a/markdown/api/library/timer/index.markdown
+++ b/markdown/api/library/timer/index.markdown
@@ -21,13 +21,13 @@ Timer functions allow calling a function some time in the future rather than imm
 
 #### [timer.pause()][api.library.timer.pause]
 
-#### [timer.pause()][api.library.timer.pauseAll]
+#### [timer.pauseAll()][api.library.timer.pauseAll]
 
 #### [timer.performWithDelay()][api.library.timer.performWithDelay]
 
 #### [timer.resume()][api.library.timer.resume]
 
-#### [timer.resume()][api.library.timer.resumeAll]
+#### [timer.resumeAll()][api.library.timer.resumeAll]
 
 ## Properties
 

--- a/markdown/api/library/timer/pause.markdown
+++ b/markdown/api/library/timer/pause.markdown
@@ -22,7 +22,7 @@ If a specific timer is paused, then the function returns a [number][api.type.Num
 	timer.pause( whatToPause )
 
 ##### whatToPause ~^(required)^~
-_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay]. Note: Using `tag` requires `Solar2D 2020.3611` or a newer build.
 
 ## Example
 

--- a/markdown/api/library/timer/pauseAll.markdown
+++ b/markdown/api/library/timer/pauseAll.markdown
@@ -14,6 +14,8 @@
 
 Pauses all timers started with [timer.performWithDelay()][api.library.timer.performWithDelay].
 
+Note: Using [timer.pauseAll()][api.library.timer.pauseAll] requires `Solar2D 2020.3611` or a newer build.
+
 ## Syntax
 
 	timer.pauseAll( timerId )

--- a/markdown/api/library/timer/performWithDelay.markdown
+++ b/markdown/api/library/timer/performWithDelay.markdown
@@ -39,7 +39,7 @@ _[Listener][api.type.Listener]._ The listener to invoke after the delay. This ma
 _[Number][api.type.Number]._ Optionally specify the number of times `listener` is to be invoked. By default, it is `1`; pass `0` or `-1` if you want the timer to loop forever.
 
 ##### tag ~^(optional)^~
-_[String][api.type.String]._ Optionally assign a `tag` to the timer. You can pause, resume or cancel all timers that share the same `tag` with a single function call.
+_[String][api.type.String]._ Optionally assign a `tag` to the timer. You can pause, resume or cancel all timers that share the same `tag` with a single function call. Note: Using `tag` requires `Solar2D 2020.3611` or a newer build.
 
 
 ## Examples

--- a/markdown/api/library/timer/resume.markdown
+++ b/markdown/api/library/timer/resume.markdown
@@ -22,7 +22,7 @@ If a specific timer is resumed, then the function returns a [number][api.type.Nu
 	timer.resume( whatToResume )
 
 ##### whatToResume ~^(required)^~
-_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay].
+_[Object][api.type.Object] or [String][api.type.String]._ The timer ID from, or `tag` passed to, [timer.performWithDelay()][api.library.timer.performWithDelay]. Note: Using `tag` requires `Solar2D 2020.3611` or a newer build.
 
 
 ## Example

--- a/markdown/api/library/timer/resumeAll.markdown
+++ b/markdown/api/library/timer/resumeAll.markdown
@@ -14,6 +14,8 @@
 
 Resumes all timers that were paused with [timer.pause()][api.library.timer.pause].
 
+Note: Using [timer.resumeAll()][api.library.timer.resumeAll] requires `Solar2D 2020.3611` or a newer build.
+
 ## Syntax
 
 	timer.resumeAll()

--- a/markdown/api/library/transition/cancelAll.markdown
+++ b/markdown/api/library/transition/cancelAll.markdown
@@ -14,6 +14,8 @@
 
 The `transition.cancelAll()` function cancels all running and paused transitions.
 
+Note: Using [transition.cancelAll()][api.library.transition.cancelAll] requires `Solar2D 2020.3611` or a newer build.
+
 
 ## Syntax
 

--- a/markdown/api/library/transition/pauseAll.markdown
+++ b/markdown/api/library/transition/pauseAll.markdown
@@ -14,6 +14,8 @@
 
 The `transition.pauseAll()` function pauses all running transitions.
 
+Note: Using [transition.pauseAll()][api.library.transition.pauseAll] requires `Solar2D 2020.3611` or a newer build.
+
 
 ## Syntax
 

--- a/markdown/api/library/transition/resumeAll.markdown
+++ b/markdown/api/library/transition/resumeAll.markdown
@@ -14,6 +14,7 @@
 
 The `transition.resumeAll()` function resumes all paused transitions.
 
+Note: Using [transition.resumeAll()][api.library.transition.resumeAll] requires `Solar2D 2020.3611` or a newer build.
 
 ## Syntax
 


### PR DESCRIPTION
There were two incorrect link names in timer library's index page.

Also, as per suggestion, this PR also adds notes on minimum version required to use the new API calls and tags in timer calls.