### PR TITLE
Making CoronaCards visible

### DIFF
--- a/bin/build.lua
+++ b/bin/build.lua
@@ -70,6 +70,7 @@ local REV_LABEL = default_rev_label
 
 local CORONA_CORE_PRODUCT = "Solar2D"
 local CORONA_NATIVE_PRODUCT = "Solar2D Native"
+local CORONA_CARDS_PRODUCT = "CoronaCards"
 
 -- Do NOT directly reference DEFAULT_REV_URL and REV_URL_BASE variables in docs. 
 -- To reference DEFAULT_REV_URL and REV_URL_BASE in the docs, use REVISION_URL.
@@ -578,6 +579,8 @@ for i=1,#markdown_files do
 				return CORONA_CORE_PRODUCT
 			elseif w == "CORONA_NATIVE_PRODUCT" then
 				return CORONA_NATIVE_PRODUCT
+			elseif w == "CORONA_CARDS_PRODUCT" then
+				return CORONA_CARDS_PRODUCT
 			elseif w == "PLUGINS_DIR" then
 				return SOLAR_LINK_PLUGINS
 			elseif w == "SOLAR_PLAY" then

--- a/markdown/404.markdown
+++ b/markdown/404.markdown
@@ -1,8 +1,8 @@
 # 404 - Not Found
 
-## Sorry, we was unable to find what you were loogin for
+## Sorry! We can't find the page you're looking for.
 
-Redirecting to [https://docs.coronalabs.com/](https://docs.coronalabs.com/) in 5 seconds...
+Redirecting to [documentation index](https://docs.coronalabs.com/) in 5 seconds...
 
 <script>
 	Array.from(document.getElementsByTagName('head')[0].children).filter(e => e.tagName=="LINK" && e.rel=="stylesheet").filter(e=>e.getAttribute('href').startsWith("css/")).forEach(function(e) {

--- a/markdown/coronacards/index.markdown
+++ b/markdown/coronacards/index.markdown
@@ -1,6 +1,6 @@
 # CoronaCards
 
-[CoronaCards](http://www.coronacards.com) is an exciting way to add interactive content into other platforms using the [thousands&nbsp;of&nbsp;APIs][api] built into CORONA_CORE_PRODUCT&nbsp;&mdash; everything from multitouch to physics to <nobr>shader-based</nobr> filters.
+[CORONA_CARDS_PRODUCT](REVISION_URL) is an exciting way to add interactive content into other platforms and frameworks such as Unity, Xamarin, Appcelerator, Apache Cordova (and any other framework that allows you to call native libraries) using the [thousands&nbsp;of&nbsp;APIs][api] built into CORONA_CORE_PRODUCT&nbsp;&mdash; everything from multitouch to physics to <nobr>shader-based</nobr> filters.
 
 <div class="guides-toc">
 

--- a/markdown/index.markdown
+++ b/markdown/index.markdown
@@ -15,7 +15,7 @@
 
 <div class="section level1" id="corona-documentation">
 <h1>
-<a href="#TOC">Solar2D Documentation</a>
+<a href="#TOC">CORONA_CORE_PRODUCT Documentation</a>
 </h1>
 
 Learn more about the CORONA_CORE_PRODUCT platform &mdash; everything you need is right here!
@@ -64,7 +64,7 @@ Monetization Guide
 
 </div>
 
-This guide will help you navigate options for monetization in Solar2D-built apps.
+This guide will help you navigate options for monetization in apps built with CORONA_CORE_PRODUCT.
 
 </a>
 </div>
@@ -112,28 +112,26 @@ CORONA_NATIVE_PRODUCT
 
 </div>
 
-Extend Solar2D with native code and wrap it behind a <nobr>cross-platform</nobr> interface.
+Extend CORONA_CORE_PRODUCT with native code and wrap it behind a <nobr>cross-platform</nobr> interface.
 
 </a>
 </div>
 
 
 <!-- CoronaCards -->
-<!---
 <div class="itembox">
 <a href="coronacards/index.html">
 <div class="itembox-header">
 <div class="itembox-icon fa fa-clone"></div>
 
-CoronaCards
+CORONA_CARDS_PRODUCT
 
 </div>
 
-Use CoronaCards to mix interactive content into your existing native apps.
+Use CORONA_CARDS_PRODUCT to mix interactive content into your existing native apps.
 
 </a>
 </div>
--->
 
 
 </div>

--- a/markdown/index.markdown
+++ b/markdown/index.markdown
@@ -96,7 +96,7 @@ Plugins
 
 </div>
 
-CORONA_CORE_PRODUCT plugins give CORONA_CORE_PRODUCT developers access to additional functionality and <nobr>third-party</nobr> services.
+Plugins give CORONA_CORE_PRODUCT developers access to additional functionality and <nobr>third-party</nobr> services.
 
 </a>
 </div>

--- a/resources/nav.markdown
+++ b/resources/nav.markdown
@@ -4,4 +4,5 @@
 * [API Reference][api]
 * [Tutorials][tutorial]
 * [Plugins][plugin]
-* [Solar2D Native][native]
+* [CORONA_NATIVE_PRODUCT][native]
+* [CORONA_CARDS_PRODUCT][coronacards]


### PR DESCRIPTION
Added constant for CoronaCards - `build.lua`
Removed link to http://coronacards.com/ and replaced it with GitHub Releases page - will add the FAQ page to docs
Added supported frameworks for CoronaCards
Added link to CoronaCards from the documentation index page
Added link to CoronaCards from the navigation bar
Fixed 404 message

CoronaCards seems to be well hidden, even though, it is still being used by developers and still included in the releases so I thought why don't we make it more visible :)