### PR TITLE
CoronaCards: Added FAQ, updated installation links

### DIFF
--- a/markdown/coronacards/android/index.markdown
+++ b/markdown/coronacards/android/index.markdown
@@ -1,14 +1,14 @@
-# CoronaCards: Getting Started — Android
+# CORONA_CARDS_PRODUCT: Getting Started — Android
 
 > --------------------- ------------------------------------------------------------------------------------------
 > __Revision__          [REVISION_LABEL](REVISION_URL)
-> __Keywords__          CoronaCards, Android
+> __Keywords__          CORONA_CARDS_PRODUCT, Android
 > --------------------- ------------------------------------------------------------------------------------------
 
 
 ## Overview
 
-Using CoronaCards, your existing Android app can leverage the full power of Corona's engine via one or more Corona-based views. These views are based on Android's `FrameLayout` and `GLSurfaceView`. They can be sized as partial or <nobr>full-screen</nobr> just like any other view.
+Using CORONA_CARDS_PRODUCT, your existing Android app can leverage the full power of CORONA_CORE_PRODUCT via one or more CORONA_CORE_PRODUCT-based views. These views are based on Android's `FrameLayout` and `GLSurfaceView`. They can be sized as partial or <nobr>full-screen</nobr> just like any other view.
 
 ## APIs
 
@@ -16,7 +16,7 @@ The native API for Android is available as [JavaDoc](html/overview-summary.html)
 
 ## Setup and Integration
 
-The following guides pertain to the setup, configuration, and integration of CoronaCards within a native app.
+The following guides pertain to the setup, configuration, and integration of CORONA_CARDS_PRODUCT within a native app.
 
 * [Project Integration — Android][coronacards.android.project]
 * [Native/Lua Communication — Android][coronacards.android.communication]
@@ -28,7 +28,7 @@ The following guides pertain to the setup, configuration, and integration of Cor
 
 ## Samples
 
-These basic samples on [GitHub](https://github.com/coronacards) exhibit the different ways in which CoronaCards can be integrated into an existing app. These samples expect the `.jar` files to be in the `libs` folder and the `.so` files in the `jniLibs` folder.
+These basic samples on [GitHub](https://github.com/coronacards) exhibit the different ways in which CORONA_CARDS_PRODUCT can be integrated into an existing app. These samples expect the `.jar` files to be in the `libs` folder and the `.so` files in the `jniLibs` folder.
 
 * [ChildView](https://github.com/coronacards/sample-android-ChildView)
 * [TabChildView](https://github.com/coronacards/sample-android-Fragment-TabChildView)

--- a/markdown/coronacards/android/project.markdown
+++ b/markdown/coronacards/android/project.markdown
@@ -1,8 +1,8 @@
-# CoronaCards: Project Integration — Android
+# CORONA_CARDS_PRODUCT: Project Integration — Android
 
 > --------------------- ------------------------------------------------------------------------------------------
 > __Revision__          [REVISION_LABEL](REVISION_URL)
-> __Keywords__          CoronaCards, Android
+> __Keywords__          CORONA_CARDS_PRODUCT, Android
 > __See also__          [Getting Started — Android][coronacards.android]
 >								[Native/Lua Communication — Android][coronacards.android.communication]
 > --------------------- ------------------------------------------------------------------------------------------
@@ -10,7 +10,7 @@
 
 ## Overview
 
-This guide explains how to integrate CoronaCards with a native Android project.
+This guide explains how to integrate CORONA_CARDS_PRODUCT with a native Android project.
 
 
 ## System Requirements
@@ -21,9 +21,9 @@ This guide explains how to integrate CoronaCards with a native Android project.
 * Android device with an __ARMv7__ processor
 
 
-## CoronaCards Installation
+## Installation
 
-Get the desired CoronaCards framework from the [download page](http://developer.coronalabs.com/downloads/coronacards) and follow the instructions to install it.
+Get the desired CORONA_CARDS_PRODUCT framework from the [download page](REVISION_URL) and follow the instructions to install it.
 
 
 ## Classes
@@ -33,19 +33,19 @@ Get the desired CoronaCards framework from the [download page](http://developer.
 
 ## Usage/Assets
 
-To use CoronaCards in the designer, you need to copy the `.jar` files into the `[Project Directory]/[Application Name]/libs` folder and the `.so` files into the `[Project Directory]/[Application Name]/src/main/jniLibs/armeabi-v7a` folder. A sample folder structure can be found on [GitHub](https://github.com/CoronaCards/sample-android-ChildView). Android Studio will show the `CoronaView` as a custom view in the designer.
+To use CORONA_CARDS_PRODUCT in the designer, you need to copy the `.jar` files into the `[Project Directory]/[Application Name]/libs` folder and the `.so` files into the `[Project Directory]/[Application Name]/src/main/jniLibs/armeabi-v7a` folder. A sample folder structure can be found on [GitHub](https://github.com/CoronaCards/sample-android-ChildView). Android Studio will show the `CoronaView` as a custom view in the designer.
 
 ### Eclipse
 
-To use CoronaCards in Eclipse, copy the `.jar` files into the `[Project Directory]/libs` folder and the `.so` files into the `[Project Directory]/libs/armeabi-v7a` folder.
+To use CORONA_CARDS_PRODUCT in Eclipse, copy the `.jar` files into the `[Project Directory]/libs` folder and the `.so` files into the `[Project Directory]/libs/armeabi-v7a` folder.
 
 ### Manifest
 
 Nothing needs to be added to the manifest.
 
-### Corona Project
+### CORONA_CORE_PRODUCT Project
 
-Place your Corona assets (i.e. `main.lua`) into the `assets` folder of your project. The `CoronaView` should then use this path:
+Place your CORONA_CORE_PRODUCT assets (i.e. `main.lua`) into the `assets` folder of your project. The `CoronaView` should then use this path:
 
 ``````
 CoronaView coronaView = new CoronaView(context);
@@ -59,8 +59,3 @@ CoronaView coronaView = new CoronaView(context);
 // Assuming 'main.lua' and all of its assets are in a folder named 'Fishies' in the 'assets' directory:
 coronaView.init("Fishies/")
 ``````
-
-
-### Licensing File
-
-The licensing file needs to be put in every directory which houses a CoronaCards project or the `CoronaView` that is pointing to that project will not run. This file ensures that you are authorized to use CoronaCards. Obtain a trial licensing file [here](https://developer.coronalabs.com/downloads/coronacards).

--- a/markdown/coronacards/faq/index.markdown
+++ b/markdown/coronacards/faq/index.markdown
@@ -1,0 +1,3 @@
+# Frequently Asked Questions
+
+

--- a/markdown/coronacards/faq/index.markdown
+++ b/markdown/coronacards/faq/index.markdown
@@ -1,3 +1,87 @@
-# Frequently Asked Questions
+# Frequently Asked Questions (FAQ)
+
+<div class="guides-toc">
+
+* [What can I do with CORONA_CARDS_PRODUCT ?](#doWhat)
+* [Why would I use CORONA_CARDS_PRODUCT ?](#useCases)
+* [Should I use CORONA_CORE_PRODUCT, CORONA_NATIVE_PRODUCT, or CORONA_CARDS_PRODUCT ?](#chooseProduct)
+* [If I use CORONA_CORE_PRODUCT or CORONA_NATIVE_PRODUCT, do I need CORONA_CARDS_PRODUCT ?](#neededProduct)
+* [Can I do the same things with CORONA_CARDS_PRODUCT and CORONA_NATIVE_PRODUCT ?](#functionality)
+* [How does CORONA_CARDS_PRODUCT work?](#worksHow)
+* [What platforms does CORONA_CARDS_PRODUCT support?](#supportedPlatforms)
+* [How should I develop the content running in CORONA_CARDS_PRODUCT ?](#developHow)
+
+</div>
 
 
+<a id="doWhat"></a>
+
+## What can I do with CORONA_CARDS_PRODUCT ?
+
+CORONA_CARDS_PRODUCT lets you take advantage of the power and ease-of-use of CORONA_CORE_PRODUCT, in any native app. You include it in your project like any other SDK and can display CORONA_CARDS_PRODUCT in any configuration (i.e., full screen, partial screen or transparent overlay).
+
+In other words, with CORONA_CORE_PRODUCT / CORONA_NATIVE_PRODUCT, the full app is built with CORONA_CORE_PRODUCT. With CORONA_CARDS_PRODUCT, you have an app built natively or in another framework and then bring CORONA_CORE_PRODUCT into the mix.
+
+Since you are using the same underlying platform, you can take advantage of almost all of CORONA_CORE_PRODUCT's 1000+ APIs. These include displaying OpenGL-accelerated graphics, audio, physics, animations and much, much more. 
+
+
+<a id="useCases"></a>
+
+## Why would I use CORONA_CARDS_PRODUCT ?
+
+There are many reasons why developers, including publishers and ad networks, use CORONA_CARDS_PRODUCT. When developers are required to use a specific platform or companies already have large investments in other platforms and don't want to adopt another platform at the moment, can use CORONA_CARDS_PRODUCT to easily add richness/interactivity to their existing apps, across all platforms, in a very fast way and without having to adopt the full CORONA_CORE_PRODUCT stack.
+
+There are also platforms, like Appcelerator and PhoneGap, that are not as well suited to rich interactive content, but that have other strengths. With CORONA_CARDS_PRODUCT inside those frameworks, developers can have the best of both worlds.
+
+
+<a id="chooseProduct"></a>
+
+## Should I use CORONA_CORE_PRODUCT, CORONA_NATIVE_PRODUCT, or CORONA_CARDS_PRODUCT ?
+
+It depends entirely on your goals and what platforms you are using today. If you are starting fresh, we would recommend to take a look at [CORONA_CORE_PRODUCT](guide.programming.intro) or [CORONA_NATIVE_PRODUCT](native). Using CORONA_CORE_PRODUCT for your full app makes the entire process much easier. CORONA_NATIVE_PRODUCT includes everything in CORONA_CORE_PRODUCT and adds the ability to call any native library or API from your app.
+
+However, if you are already using an alternative platform or need to work on an existing non-CORONA_CORE_PRODUCT app, then CORONA_CARDS_PRODUCT is probably the way to go. It will let you easily add CORONA_CORE_PRODUCT richness into those apps/platforms.
+
+
+<a id="neededProduct"></a>
+
+## If I use CORONA_CORE_PRODUCT or CORONA_NATIVE_PRODUCT, do I need CORONA_CARDS_PRODUCT ?
+
+Probably not. CORONA_CARDS_PRODUCT is primarily relevant for developers actively using other platforms or that have apps built with other platforms. 
+
+
+<a id="functionality"></a>
+
+## Can I do the same things with CORONA_CARDS_PRODUCT and CORONA_NATIVE_PRODUCT ?
+
+Yes, but you would be accomplishing them in a different way.
+
+With CORONA_NATIVE_PRODUCT you are using CORONA_CORE_PRODUCT for the core of your app and you are then calling native libraries from within CORONA_CORE_PRODUCT. With CORONA_CARDS_PRODUCT, your app is built in another platform (or natively) and you are using CORONA_CORE_PRODUCT inside that app.
+
+Either way, you would be combining CORONA_CORE_PRODUCT with native libraries. What method you prefer is really up to you and your project's requirements.
+
+
+<a id="worksHow"></a>
+
+## How does CORONA_CARDS_PRODUCT work?
+
+Take a look at the [documentation and guides](coronacards). We have information on how to get started with native iOS and Android, as well as several other frameworks.
+
+
+<a id="supportedPlatforms"></a>
+
+## What platforms does CORONA_CARDS_PRODUCT support?
+
+Today we support iOS, Android and HTML5 is in beta. Although it is obsolete, you can also use CORONA_CARDS_PRODUCT on Windows Phone 8 and 10 Mobile.
+Essentially, any platform supported by CORONA_CORE_PRODUCT will probably be supported by CORONA_CARDS_PRODUCT since they are built on the same underlying core.
+
+You can also use CORONA_CARDS_PRODUCT within frameworks like Appcelerator, PhoneGap, Unity and Xamarin (and any other framework that allows you to call native libraries). 
+
+
+<a id="developHow"></a>
+
+## How should I develop the content running in CORONA_CARDS_PRODUCT ?
+
+We recommend that you use the CORONA_CORE_PRODUCT Simulator and a [text editor/IDE](guide.programming.01#text-editors), just as a regular CORONA_CORE_PRODUCT developer would. The simulator gives you the quick development and iteration speed and lets you use all CORONA_CORE_PRODUCT APIs to build things out. You can then put your lua files and assets into your project and run it within CORONA_CARDS_PRODUCT.
+
+Just download [CORONA_CORE_PRODUCT](REVISION_URL) and you'll be building in no time.

--- a/markdown/coronacards/index.markdown
+++ b/markdown/coronacards/index.markdown
@@ -7,6 +7,6 @@
 * [iOS][coronacards.ios]
 * [Android][coronacards.android]
 * [Windows Phone 8 + Windows 10 Mobile][coronacards.wp8]
-* [FAQ][coronacards.faq]
+* [Frequently Asked Questions (FAQ)][coronacards.faq]
 
 </div>

--- a/markdown/coronacards/index.markdown
+++ b/markdown/coronacards/index.markdown
@@ -7,5 +7,6 @@
 * [iOS][coronacards.ios]
 * [Android][coronacards.android]
 * [Windows Phone 8 + Windows 10 Mobile][coronacards.wp8]
+* [FAQ][coronacards.faq]
 
 </div>

--- a/markdown/coronacards/ios/index.markdown
+++ b/markdown/coronacards/ios/index.markdown
@@ -1,6 +1,6 @@
-# CoronaCards &mdash; iOS
+# CORONA_CARDS_PRODUCT &mdash; iOS
 
-Using CoronaCards, your existing iOS app can leverage the full power of Corona's engine via one or more <nobr>Corona-based</nobr> views (`CoronaView`). These views are based on the iOS `GLKView` and can be inserted into the `UIView` hierarchy. They can be sized as partial or <nobr>full-screen</nobr> just like any other `UIView` and may even be shown as transparent overlays on top of existing content.
+Using CORONA_CARDS_PRODUCT, your existing iOS app can leverage the full power of CORONA_CORE_PRODUCT via one or more <nobr>CORONA_CORE_PRODUCT-based</nobr> views (`CoronaView`). These views are based on the iOS `GLKView` and can be inserted into the `UIView` hierarchy. They can be sized as partial or <nobr>full-screen</nobr> just like any other `UIView` and may even be shown as transparent overlays on top of existing content.
 
 
 ## System Requirements
@@ -11,7 +11,7 @@ Using CoronaCards, your existing iOS app can leverage the full power of Corona's
 
 ## Installation
 
-Get the desired CoronaCards framework from the [download](http://developer.coronalabs.com/downloads/coronacards) page and follow the instructions to install it.
+Get the desired CORONA_CARDS_PRODUCT framework from the [download](REVISION_URL) page and follow the instructions to install it.
 
 
 ## Setup and Integration
@@ -40,7 +40,7 @@ Get the desired CoronaCards framework from the [download](http://developer.coron
 
 ## Samples
 
-The following basic samples are available on [GitHub](https://github.com/coronacards). They exhibit the different ways in which CoronaCards can be integrated into an existing app. These samples expect `CoronaKit.framework` to be installed in `/Users/Shared/CoronaLabs/ios/`. See the [setup][coronacards.ios.setup] guide for more information.
+The following basic samples are available on [GitHub](https://github.com/coronacards). They exhibit the different ways in which CORONA_CARDS_PRODUCT can be integrated into an existing app. These samples expect `CoronaKit.framework` to be installed in `/Users/Shared/CoronaLabs/ios/`. See the [setup][coronacards.ios.setup] guide for more information.
 
 * [SimpleView (Obj-C)](https://github.com/coronacards/sample-ios-SimpleView)
 * [SimpleView (Swift)](https://github.com/coronacards/sample-ios-SimpleView-swift)

--- a/markdown/guide/basics/index.markdown
+++ b/markdown/guide/basics/index.markdown
@@ -1,4 +1,4 @@
-# Corona Basics
+# Basics
 
 <div class="guides-toc">
 

--- a/markdown/guide/programming/intro/index.markdown
+++ b/markdown/guide/programming/intro/index.markdown
@@ -249,9 +249,9 @@ If you're new to CORONA_CORE_PRODUCT or app development, download [CORONA_CORE_P
 
 CORONA_NATIVE_PRODUCT provides <nobr>low-level</nobr> access to the operating system and native&nbsp;APIs. While most apps designed using CORONA_CORE_PRODUCT do not require this level of access, it allows you to use native languages like <nobr>Obj-C</nobr> or Java to pass information between the native code and Lua code.
 
-### CoronaCards
+### CORONA_CARDS_PRODUCT
 
-[CoronaCards](http://coronacards.com/) is used to implement CORONA_CORE_PRODUCT inside native apps or other frameworks. This allows developers to embed CORONA_CORE_PRODUCT resources without interfering with the main application stack.
+[CORONA_CARDS_PRODUCT](coronacards) is used to implement CORONA_CORE_PRODUCT inside native apps or other frameworks. This allows developers to embed CORONA_CORE_PRODUCT resources without interfering with the main application stack.
 
 
 


### PR DESCRIPTION
Added FAQ page from CoronaCards.com. Edited it a little bit and used constants for Solar2D product references.
Updated installation links for iOS and Android. Haven't done the same for Windows Phone though :D
Android: Removed licensing reference though I'm not sure if it's still necessary but the link was not working. You may want to look into this before merging.

Small fixes:
Edited `Getting Started` guide to use `CORONA_CARDS_PRODUCT` variable
Removed branding on `Basics` page