### PR TITLE
Small updates to network API and rebranding for REST tutorial

### DIFF
--- a/markdown/api/library/network/canDetectNetworkStatusChanges.markdown
+++ b/markdown/api/library/network/canDetectNetworkStatusChanges.markdown
@@ -30,7 +30,7 @@ local function networkListener( event )
 end
 
 if ( network.canDetectNetworkStatusChanges ) then
-    network.setStatusListener( "www.coronalabs.com", networkListener )
+    network.setStatusListener( "https://solar2d.com/", networkListener )
 else
     print( "Network reachability not supported on this platform." )
 end

--- a/markdown/api/library/network/canDetectNetworkStatusChanges.markdown
+++ b/markdown/api/library/network/canDetectNetworkStatusChanges.markdown
@@ -30,7 +30,7 @@ local function networkListener( event )
 end
 
 if ( network.canDetectNetworkStatusChanges ) then
-    network.setStatusListener( "https://solar2d.com/", networkListener )
+    network.setStatusListener( "www.solar2d.com", networkListener )
 else
     print( "Network reachability not supported on this platform." )
 end

--- a/markdown/api/library/network/cancel.markdown
+++ b/markdown/api/library/network/cancel.markdown
@@ -63,7 +63,7 @@ local function networkListener( event )
 
     if ( event.isError ) then
         print( "Network error: ", event.response )
-    elseif ( event.phase == "began" ) and ( event.bytesEstimated > 1000000 ) then
+    elseif ( event.phase == "began" ) and ( event.bytesEstimated > 80000 ) then
         print( "Canceling request, file is too big!" )
         network.cancel( event.requestId )
     end

--- a/markdown/api/library/network/cancel.markdown
+++ b/markdown/api/library/network/cancel.markdown
@@ -71,10 +71,10 @@ end
 
 -- Start the image download
 network.download(
-    "http://www.coronalabs.com/demo/hello.png",
+    "https://plugins.solar2d.com/images/logo-banner.png",
     "GET",
     networkListener,
     { progress = true },
-    "helloCopy.png",
+    "bannerCopy.png",
     system.TemporaryDirectory )
 ``````

--- a/markdown/api/library/network/download.markdown
+++ b/markdown/api/library/network/download.markdown
@@ -24,7 +24,7 @@ This function returns a handle that can be passed to [network.cancel()][api.libr
 
 ## Gotchas
 
-You cannot execute a network download during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. After Corona suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending download saved and, if so, execute it.
+You cannot execute a network download during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. When your application suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending download saved and, if so, execute it.
 
 Network requests do not raise runtime errors in the event of failure so there is no need to wrap them in a Lua `pcall()` statement (errors are reported in the event sent to the network listener).
 
@@ -102,7 +102,7 @@ network.download(
 	"GET",
 	networkListener,
 	params,
-	"helloCopy.png",
+	"maskCopy.png",
 	system.TemporaryDirectory
 )
 ``````

--- a/markdown/api/library/network/request.markdown
+++ b/markdown/api/library/network/request.markdown
@@ -20,7 +20,7 @@ Makes an asynchronous HTTP or HTTPS request to a URL. This function returns a ha
 
 ## Gotchas
 
-* You cannot execute a network request during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. After Corona suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending request saved and, if so, execute it.
+* You cannot execute a network request during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. When your application suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending request saved and, if so, execute it.
 
 * The `Content-Type` of requests defaults to `text/plain`. If you're `POST`-ing form data, you must set it appropriately <nobr>(see the [example](#HTTP_POST_with_custom_headers) below).</nobr>
 
@@ -89,7 +89,7 @@ Note that if a `filename` table is specified in `params.body` or in `params.resp
 ``````lua
 -- The following sample code contacts Google's encrypted search over SSL
 -- and prints the response (in this case, the HTML source of the home page)
--- to the Corona terminal.
+-- to the console.
 
 local function networkListener( event )
 
@@ -171,7 +171,7 @@ params.progress = "download"
 
 -- Tell network.request() that we want the output to go to a file:
 params.response = {
-    filename = "corona.jpg",
+    filename = "solar.jpg",
     baseDirectory = system.DocumentsDirectory
 }
  

--- a/markdown/api/library/network/setStatusListener.markdown
+++ b/markdown/api/library/network/setStatusListener.markdown
@@ -30,7 +30,7 @@ Starts monitoring a host for its network reachability status. This API is design
 	network.setStatusListener( hostURL, listener )
 
 ##### hostURL ~^(required)^~
-_[String][api.type.String]._ The host you want to monitor. This may be something like `"www.coronalabs.com"`. You should not include `http://` or the port number.
+_[String][api.type.String]._ The host you want to monitor. This may be something like `"www.solar2d.com"`. You should not include `http://` or the port number.
 
 ##### listener ~^(required)^~
 _[Listener][api.type.Listener]._ The listener that gets [networkStatus][api.event.networkStatus] events for the specified host. Pass `nil` to unregister the listener that's set for the specified host.

--- a/markdown/api/library/network/upload.markdown
+++ b/markdown/api/library/network/upload.markdown
@@ -22,7 +22,7 @@ This function returns a handle that can be passed to [network.cancel()][api.libr
 
 ## Gotchas
 
-You cannot execute a network upload during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. After Corona suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending upload saved and, if so, execute it.
+You cannot execute a network upload during an `applicationSuspend` or `applicationExit` [event][api.event.system.type]. When your application suspends, no callbacks will fire. You can work around this by saving the request you wish to make to a file upon suspension. Then, on an `applicationResume` [event][api.event.system.type], check if there is a pending upload saved and, if so, execute it.
 
 Network requests do not raise runtime errors in the event of failure so there is no need to wrap them in a Lua `pcall()` statement (errors are reported in the event sent to the network listener).
 

--- a/markdown/tutorial/social/connectREST/index.markdown
+++ b/markdown/tutorial/social/connectREST/index.markdown
@@ -1,7 +1,7 @@
 
 # Connecting to REST API Services
 
-One of the "hidden" powers of Corona is the ability to connect to various online services to get data into your app. To accomplish this, a popular option is __REST__ (or&nbsp;RESTful) APIs which are based on standard HTTP protocols and are generally easy to authenticate.
+Using CORONA_CORE_PRODUCT, you can connect to various online services to get data into your app. To accomplish this, a popular option is __REST__ (or&nbsp;RESTful) APIs which are based on standard HTTP protocols and are generally easy to authenticate.
 
 
 ## REST Overview
@@ -26,7 +26,7 @@ Let's inspect this in more detail:
 
 * Following this is typically the category of functionality. In this example, all of Twitter's "friends" APIs are grouped under the `/friends` family.
 
-* Finally, the specific `/list` API will fetch a list of the current user's friends, conveniently formatted in JSON which is easily compatible with Corona (alternatively,&nbsp;some services allow you to request XML data by specifying `.xml` instead of&nbsp;`.json`).
+* Finally, the specific `/list` API will fetch a list of the current user's friends, conveniently formatted in JSON which is easily compatible with CORONA_CORE_PRODUCT (alternatively,&nbsp;some services allow you to request XML data by specifying `.xml` instead of&nbsp;`.json`).
 
 
 ## Authentication
@@ -34,7 +34,7 @@ Let's inspect this in more detail:
 Most REST APIs require some form of verification or authentication, in particular if you're trying to add or update data. Authentication can occur in various ways, for example by passing the username and password as part of the domain name:
 
 ``````
-http://username:password@api.yoursite.com/someapi/dosomething.json
+https://username:password@api.yoursite.com/someapi/dosomething.json
 ``````
 
 In this example, the `username:password` method is a shortcut to using a headers table. Sometimes the username and password will be referred to as the "API&nbsp;Key" and "secret" and they may need to be encoded in some fashion such as [MD5][api.library.crypto].
@@ -44,7 +44,7 @@ An alternate method is to use a __headers__ table, discussed in more detail belo
 
 ## Making API Calls
 
-In Corona, your REST API calls are made via [network.request()][api.library.network.request]. For this API, you provide a URL, an HTTP "verb," a callback function to handle the completed request, and an optional table of information in which to handle headers and data passed to the server.
+Your REST API calls are made via [network.request()][api.library.network.request]. For this API, you need to provide a URL, an HTTP "verb", a callback function to handle the completed request, and an optional table of information in which to handle headers and data passed to the server.
 
 ### Basic Request
 


### PR DESCRIPTION
Replaced branding with constants for "Connecting to REST API Services" tutorial (https://docs.coronalabs.com/tutorial/social/connectREST/index.html)
Replaced broken links in `network.*` and updated sample codes to reflect changes
Replaced branding with constants in `network.*`