### PR TITLE
Updated links and rebranding

### DIFF
--- a/bin/aliases.lua
+++ b/bin/aliases.lua
@@ -17,6 +17,7 @@ return {
 	{ real="events", shown="Events/Listeners" },
 	{ real="graphics", shown="Graphics/Audio/Animation" },
 	{ real="hardware", shown="System/Hardware" },
+	{ real="html5", shown="HTML5" },
 	{ real="media", shown="Graphics/Audio/Animation" },
 	{ real="monetization", shown="Ads/Monetization" },
 	{ real="physics", shown="Physics" },

--- a/markdown/api/library/display/loadRemoteImage.markdown
+++ b/markdown/api/library/display/loadRemoteImage.markdown
@@ -97,7 +97,7 @@ local function networkListener( event )
     print ( "event.response.baseDirectory: ", event.response.baseDirectory )
 end
  
-display.loadRemoteImage( "http://coronalabs.com/images/coronalogogrey.png", "GET", networkListener, "coronalogogrey.png", system.TemporaryDirectory, 50, 50 )
+display.loadRemoteImage( "https://plugins.solar2d.com/images/logo-banner.png", "GET", networkListener, "logo-banner.png", system.TemporaryDirectory, 50, 50 )
 `````
 
 ##### Cancel Remote Load Before Completion
@@ -181,5 +181,5 @@ display.loadRemoteImage = function( url, method, listener, ... )
 end
 
 display.loadRemoteImage( 
-    "http://coronalabs.com/images/coronalogogrey.png", "GET", networkListener, "coronalogogrey.png", system.TemporaryDirectory, display.contentCenterX, display.contentCenterY )
+    "https://plugins.solar2d.com/images/logo-banner.png", "GET", networkListener, "logo-banner.png", system.TemporaryDirectory, display.contentCenterX, display.contentCenterY )
 ``````

--- a/markdown/guide/html5/plugins/index.markdown
+++ b/markdown/guide/html5/plugins/index.markdown
@@ -22,7 +22,7 @@ HTML5 builds are still in beta. Things in this guide may be subject for changes.
 
 </div>
 
-HTML5 provides extremely rich access to a variety of APIs, both built-in and third party integrations. It would be impossible to create bindings for all of them in Lua. This is why Corona provides an extremely easy way to bridge between Lua and JavaScript code.
+HTML5 provides extremely rich access to a variety of APIs, both built-in and third party integrations. It would be impossible to create bindings for all of them in Lua. This is why CORONA_CORE_PRODUCT provides an extremely easy way to bridge between Lua and JavaScript code.
 
 <a id="plugin"></a>
 
@@ -113,7 +113,7 @@ You should see that everything works as expected. Methods are getting called, pr
 
 ### Passing functions to JavaScript
 We have already seen that it is very straightforward to call JavaScript functions from Lua. But it is often required to do the reverse - invoke a callback to Lua when some JavaScript async operations is finished. This is tricky, since JavaScript doesn't provide any mechanisms to interact with its garbage collector. Simpler, value types like strings, numbers or event tables can be copied between Lua and JavaScript, so memory leaks are not a problem because copies are handled separately on each side. Functions on other hand, must maintain connection to their environment in order to perform expected tasks.
-Nevertheless, Corona provides two ways that allow Lua functions can be passed to Javascript:
+Nevertheless, CORONA_CORE_PRODUCT provides two ways that allow Lua functions can be passed to Javascript:
 
 <a id="funcToJsProp"></a>
 
@@ -198,7 +198,7 @@ demo_plugin_js = {
 
 ## Plugin example
 
-To see example of real-world plugin check out our VK Direct Games plugin available on [bitbucket](https://bitbucket.org/coronalabs/store-hosted-vk-direct/src/default/plugins/2018.3275/web/plugin_vk_direct_js.js). Lets review some notable parts.
+To see example of real-world plugin check out our VK Direct Games plugin available on [GitHub](https://github.com/coronalabs/com.coronalabs-plugin.vk.direct/blob/master/plugins/2018.3275/web/plugin_vk_direct_js.js). Lets review some notable parts.
 
 #### `init()`
 Function `init()` is most interesting. It has 2 parts. First - it remembers callback to dispatch events to:
@@ -263,10 +263,10 @@ local metadata = {
 return metadata
 ```
 
-Use [VK Direct Games plugin](https://bitbucket.org/coronalabs/store-hosted-vk-direct/src/default/plugins/2018.3275/web/plugin_vk_direct_js.js) as an example.
+Use [VK Direct Games plugin](https://github.com/coronalabs/com.coronalabs-plugin.vk.direct/blob/master/plugins/2018.3275/web/plugin_vk_direct_js.js) as an example.
 
 <a id="support"></a>
 
 ## Support
 
-If you have any questions or ideas, feel free to join community discussions on our [HTML5 forum](https://forums.coronalabs.com/forum/637-html5/) or #html5 channel on [Slack](https://coronalabs.com/slack).
+If you have any questions or ideas, feel free to join community discussions on the [forums](https://forums.solar2d.com/c/beta-testing/html5/96) or [Discord](https://discord.gg/Abf5V9G).


### PR DESCRIPTION
Added alias for HTML5 - navigation bar was showing "Documentation  ▸  Developer Guides  ▸  [html5][guide.html5] "
Hopefully, this will fix it.

Replaced image links on `display.loadRemoteImage`

Replaced broken links for VK Direct Games plugin repository to GitHub - `HTML5 guide`
Replaced branding to constant - `HTML5 guide`
Replaced forum links and added link to Discord - `HTML5 guide`
Replaced branding with constant - `HTML5 guide`