### PR TITLE
Remove duplicate text from incorrect location

### DIFF
--- a/markdown/api/library/system/getInfo.markdown
+++ b/markdown/api/library/system/getInfo.markdown
@@ -53,8 +53,6 @@ _[String][api.type.String]._ The name of the property corresponding to the desir
 
 `"bundleID"` returns bundle/package identifier of the app or `nil` if not applicable.
 
-`"build"` returns the Corona build string as it appears in the __About__ box of the Corona Simulator.
-
 ### darkMode
 `"darkMode"` returns either `true` or `false` on platforms that support Dark Mode.
 


### PR DESCRIPTION
The "build" property is already correctly explained under its corresponding heading at https://docs.coronalabs.com/api/library/system/getInfo.html#build. This is PR just removes the accidental duplicate text from under the bundleID heading.

