### PR TITLE
Update LFS reference link, bump version number

### DIFF
--- a/bin/build.lua
+++ b/bin/build.lua
@@ -20,7 +20,7 @@ links to markdown files, and converting markdown source files to html.
 - LuaFileSystem: https://lunarmodules.github.io/luafilesystem/
 - Pandoc: http://johnmacfarlane.net/pandoc/
 
-- LuaFileSystem(dead link): http://keplerproject.github.com/luafilesystem/
+- LuaFileSystem(old link): http://keplerproject.github.com/luafilesystem/
 
 ## USAGE:
 
@@ -66,7 +66,7 @@ local output_images_dir = html_dir .. "/images"
 
 -- strings to substitute throughout docs content (not headers or footers though)
 local title_prefix = "Solar2D Documentation"
-local default_rev_label = "Release 2022.3682"
+local default_rev_label = "Release 2022.3683"
 local REV_LABEL = default_rev_label
 
 local CORONA_CORE_PRODUCT = "Solar2D"

--- a/bin/build.lua
+++ b/bin/build.lua
@@ -17,9 +17,10 @@ links to markdown files, and converting markdown source files to html.
 ### External Resources:
 
 - Lua: http://lua.org
-- LuaFileSystem: http://keplerproject.github.com/luafilesystem/
+- LuaFileSystem: https://lunarmodules.github.io/luafilesystem/
 - Pandoc: http://johnmacfarlane.net/pandoc/
 
+- LuaFileSystem(dead link): http://keplerproject.github.com/luafilesystem/
 
 ## USAGE:
 

--- a/markdown/api/library/lfs/index.markdown
+++ b/markdown/api/library/lfs/index.markdown
@@ -4,7 +4,7 @@
 > __Type__              [Library][api.type.Library]
 > __Revision__          [REVISION_LABEL](REVISION_URL)
 > __Keywords__          lfs, LuaFileSystem, files, file system
-> __See also__          [LuaFileSystem Reference](https://keplerproject.github.io/luafilesystem/manual.html#reference)
+> __See also__          [LuaFileSystem Reference](https://lunarmodules.github.io/luafilesystem/manual.html#reference)
 > --------------------- ------------------------------------------------------------------------------------------
 
 ## Overview

--- a/markdown/guide/data/LFS/index.markdown
+++ b/markdown/guide/data/LFS/index.markdown
@@ -155,4 +155,4 @@ The value returned for the timestamp will be the number of seconds since <nobr>J
 
 ## Further Reference
 
-LFS is very powerful and it can do much more than what is illustrated in this guide. Fortunately, most of the LFS functions are straightforward and easy to use. Please see the [LFS Reference](https://keplerproject.github.io/luafilesystem/manual.html#reference) for a complete listing of available functions and syntax details for each one.
+LFS is very powerful and it can do much more than what is illustrated in this guide. Fortunately, most of the LFS functions are straightforward and easy to use. Please see the [LFS Reference](https://lunarmodules.github.io/luafilesystem/manual.html#reference) for a complete listing of available functions and syntax details for each one.


### PR DESCRIPTION
Old link to Kepler Project GitHub was dead. Looking at [this](https://github.com/lunarmodules/luafilesystem/commit/912e06714fc276c15b4d5d1b42bd2b11edb8deff) and some other Google searches, they seem to have moved to Lunar Modules. I updated the links to reflect that change. Still, I'd prefer a second opinion on this.

I also kept the old link in `build.lua` for archival purposes.