### PR TITLE
Fix LuaSocket broken link

### DIFF
--- a/markdown/api/library/socket/index.markdown
+++ b/markdown/api/library/socket/index.markdown
@@ -4,7 +4,7 @@
 > __Type__              [Library][api.type.Library]
 > __Revision__          [REVISION_LABEL](REVISION_URL)
 > __Keywords__          socket, LuaSocket, networking
-> __See also__          [LuaSocket Documentation](https://rawgit.com/diegonehab/luasocket/master/doc/reference.html)
+> __See also__          [LuaSocket Documentation](https://lunarmodules.github.io/luasocket/reference.html)
 >						[network.request()][api.library.network.request]
 >						[network.download()][api.library.network.download]
 >						[network.canDetectNetworkStatusChanges][api.library.network.canDetectNetworkStatusChanges]


### PR DESCRIPTION
"See also	LuaSocket Documentation" in [socket.*](https://docs.coronalabs.com/api/library/socket/index.html), was expected refer to LuaSocket reference.