### PR TITLE
Add warning and link to Activity Popup plugin

### DIFF
--- a/markdown/plugin/CoronaProvider_native_popup_social/index.markdown
+++ b/markdown/plugin/CoronaProvider_native_popup_social/index.markdown
@@ -4,12 +4,23 @@
 > __Type__              [CoronaProvider][api.type.CoronaProvider]
 > __Revision__          [REVISION_LABEL](REVISION_URL)
 > __Keywords__          native, showPopup, social
-> __Platforms__			Android, iOS
+> __Platforms__			Android
 > --------------------- ------------------------------------------------------------------------------------------
 
 ## Overview
 
 The Social Popup plugin enables you to post a message to various social providers.
+
+<div class="docs-tip-outer docs-tip-color-alert" style="width: 100%;">
+<div class="docs-tip-inner-left">
+<div class="fa fa-exclamation-circle" style="font-size: 35px;"></div>
+</div>
+<div class="docs-tip-inner-right">
+
+For iOS 8 and later, you have to use [Activity Popup][plugin.CoronaProvider_native_popup_activity] plugin.
+
+</div>
+</div>
 
 
 ## Functions


### PR DESCRIPTION
Addressing issue #79 
Removed `iOS` from supported platforms list since iOS 8 is obsolete