### PR TITLE
Add warning and link to Social Popup plugin

### DIFF
--- a/markdown/plugin/CoronaProvider_native_popup_activity/index.markdown
+++ b/markdown/plugin/CoronaProvider_native_popup_activity/index.markdown
@@ -11,6 +11,16 @@
 
 The Activity Popup plugin displays the activity popup window which corresponds to `UIActivityViewController` on iOS.
 
+<div class="docs-tip-outer docs-tip-color-alert" style="width: 100%;">
+<div class="docs-tip-inner-left">
+<div class="fa fa-exclamation-circle" style="font-size: 35px;"></div>
+</div>
+<div class="docs-tip-inner-right">
+
+For Android, you have to use [Social Popup][plugin.CoronaProvider_native_popup_social] plugin.
+
+</div>
+</div>
 
 ## Syntax
 
@@ -39,8 +49,3 @@ settings =
 	},
 }
 ``````
-
-
-## Support
-
-* [Corona Forums](http://forums.coronalabs.com/forum/631-corona-premium-plugins/)


### PR DESCRIPTION
This is to link two plugins together so developers don't waste time searching.
- Add warning to use Social Popup for Android
- Add link to Social Popup(Android) from Activity Popup(iOS)
- Remove link to forums