### PR TITLE
Fix incorrect internal link & update wording

### DIFF
--- a/markdown/api/library/store/index.markdown
+++ b/markdown/api/library/store/index.markdown
@@ -18,7 +18,7 @@ For in-app purchasing on other platforms, see the documentation for [Google Bill
 <div class="guide-notebox">
 <div class="notebox-title">Notes</div>
 
-* This is the legacy version of the Apple store IAP, please see the new [Apple IAP Plugin][plugin.amazon-iap-v3]
+* This is the legacy version of the Apple store IAP, please use the new [Apple IAP Plugin][plugin.apple-iap].
 
 * To use <nobr>in-app</nobr> purchases on iOS, you must first configure your iOS certificates, App&nbsp;IDs, and provisioning profiles. Please review our [Provisioning and Building][guide.distribution.iOSBuild] guide thoroughly, as this is an essential task and you must complete each step correctly. Also remember to create an App&nbsp;ID that is unique and fully qualified, __not__ a wildcard App&nbsp;ID.
 


### PR DESCRIPTION
The link was intended to direct to Apple IAP plugin, but was instead directing to Amazon IAP.

Also updated the wording from "please see the new plugin" to "please use the new plugin".