### PR TITLE
Remove references to Atom editor

### DIFF
--- a/markdown/guide/programming/01/index.markdown
+++ b/markdown/guide/programming/01/index.markdown
@@ -43,7 +43,6 @@ If you don't already have a favorite text editor, the following options are reco
 Editor																Add-On Package																					 macOS		 Windows
 ------------------------------------------------------------------	----------------------------------------------------------------------------------------------	----------	----------
 [Sublime Text](https://www.sublimetext.com)							[Solar2D Editor](https://github.com/coronalabs/CoronaSDK-SublimeText)	     					 &#x2713;	 &#x2713;
-[Atom](https://atom.io)												[autocomplete-corona](https://atom.io/packages/autocomplete-corona)	    					     &#x2713;	 &#x2713;
 [Visual Studio Code](https://code.visualstudio.com/)				[Solar2d Autocomplete](https://bit.ly/3IfNx6e)	    											 &#x2713;	 &#x2713;
 [Xcode](https://developer.apple.com/xcode/)							[Xcode Editor](https://github.com/jcbnlsn/Xcode-Corona-Editor)									 &#x2713;
 [Vim](https://www.vim.org)																																			 &#x2713;	 &#x2713;

--- a/markdown/guide/start/installMac/index.markdown
+++ b/markdown/guide/start/installMac/index.markdown
@@ -124,7 +124,6 @@ You'll need a text editor or IDE to write code for your CORONA_CORE_PRODUCT proj
 Editor																Add-On Package
 ------------------------------------------------------------------	---------------------------------------------
 [Sublime Text](https://www.sublimetext.com)							[Solar2D Editor](https://github.com/coronalabs/CoronaSDK-SublimeText)
-[Atom](https://atom.io)												[autocomplete-corona](https://atom.io/packages/autocomplete-corona)
 [Visual Studio Code](https://code.visualstudio.com/)				[Solar2d-companion](https://marketplace.visualstudio.com/items?itemName=M4adan.solar2d-companion)
 [Xcode](https://developer.apple.com/xcode/)							[Xcode Editor](https://github.com/jcbnlsn/Xcode-Corona-Editor)
 [ZeroBrane Studio](https://studio.zerobrane.com)
@@ -158,7 +157,7 @@ The CORONA_CORE_PRODUCT Simulator for macOS features the following basic menu it
 
 * The standard macOS application menu provides access to the Simulator __Preferences__. It also lets you manually open/run __Corona&nbsp;Live&nbsp;Server__ for doing [Live Builds][guide.distribution.liveBuild] on actual devices.
 
-* The __File__ menu is where projects (applications) are created or opened. This is also where you __build__ your apps for distribution or testing on devices. 
+* The __File__ menu is where projects (applications) are created or opened. This is also where you __build__ your apps for distribution or testing on devices.
 
 * The __Hardware__ menu is used to simulate physical device actions such as rotating the screen.
 

--- a/markdown/guide/start/installWin/index.markdown
+++ b/markdown/guide/start/installWin/index.markdown
@@ -90,7 +90,6 @@ You'll need a text editor or IDE to write code for your CORONA_CORE_PRODUCT proj
 Editor																Add-On Package
 ------------------------------------------------------------------	---------------------------------------------
 [Sublime Text](https://www.sublimetext.com)							[CORONA_CORE_PRODUCT Editor](https://github.com/coronalabs/CoronaSDK-SublimeText)
-[Atom](https://atom.io)												[autocomplete-corona](https://atom.io/packages/autocomplete-corona)
 [Visual Studio Code](https://code.visualstudio.com/)				[CORONA_CORE_PRODUCT-companion](https://marketplace.visualstudio.com/items?itemName=M4adan.solar2d-companion)
 [Notepad++](https://notepad-plus-plus.org)
 [ZeroBrane Studio](https://studio.zerobrane.com)


### PR DESCRIPTION
Atom was officially discontinued by Microsoft/GitHub in December 2022 and so it shouldn't be recommended as a viable editor in the docs.