### PR TITLE
Google IAP - update purchase() and purchaseSubscription() pages

### DIFF
--- a/markdown/plugin/google-iap-billing-v2/purchase.markdown
+++ b/markdown/plugin/google-iap-billing-v2/purchase.markdown
@@ -18,7 +18,7 @@ Initiates a purchase transaction on a provided product by sending out a purchase
 
 ## Gotchas
 
-This call does not work for subscription purchases.
+This call does not work for subscription purchases. Use [store.purchaseSubscription()][plugin.google-iap-billing-v2.purchaseSubscription] instead.
 
 
 ## Syntax

--- a/markdown/plugin/google-iap-billing-v2/purchaseSubscription.markdown
+++ b/markdown/plugin/google-iap-billing-v2/purchaseSubscription.markdown
@@ -15,12 +15,6 @@
 
 Initiates a purchase transaction on a provided product by sending out a purchase request to the store, then dispatches a [storeTransaction][plugin.google-iap-billing-v2.event.storeTransaction] event to the listener defined in [store.init()][plugin.google-iap-billing-v2.init].
 
-
-## Gotchas
-
-This call does not work for subscription purchases.
-
-
 ## Syntax
 
 	store.purchaseSubscription( productIdentifier [, options] )


### PR DESCRIPTION
Removed the incorrect statement from `purchaseSubscription()` Gotchas section.
Linked to `purchaseSubscription()` from `purchase()`.