### PR TITLE
Fix build.settings and add important notice to Age Range plugin

### DIFF
--- a/markdown/plugin/ageRange/index.markdown
+++ b/markdown/plugin/ageRange/index.markdown
@@ -79,7 +79,7 @@ settings =
 {
     iphone =
     {
-        plist =
+        entitlements =
         {
             -- Required for Declared Age Range
             ["com.apple.developer.declared-age-range"] = true,
@@ -87,6 +87,14 @@ settings =
     },
 }
 ``````
+
+<div class="guide-notebox-imp">
+<div class="notebox-title-imp">Important</div>
+
+You need to add Declared Age Range as an Entitlement to your project identifiers on App Store Connect and create a new Provisioning Profile.
+
+</div>
+
 
 ### Android Requirements
 


### PR DESCRIPTION
Added entitlements for Declared Age Range in iOS settings and included important notes for App Store Connect.

Addressing #214 