### PR TITLE
advancedSettings: document Minimum iOS Version

### DIFF
--- a/markdown/api/library/json/encode.markdown
+++ b/markdown/api/library/json/encode.markdown
@@ -35,9 +35,40 @@ _[Table][api.type.Table]._ Lua table containing optional directives to the JSON 
 3. All control chars are encoded to `\uXXXX` format, for example `"\021"` encodes to `"\u0015"`.
 4. All JSON `\uXXXX` chars are decoded to chars (`0`-`255` byte range only).
 5. JSON single line `//` and `/* */` block comments are discarded during decoding.
-6. Numerically indexed Lua arrays are encoded to JSON lists, for example `[1,2,3]`.
+6. A Lua table is encoded to a JSON array when all of its keys are positive integers (gaps are permitted), for example `[1,2,3]`. The presence of any key that isn't a positive integer forces the entire table to be encoded as a JSON object instead.
 7. Lua dictionary tables are converted to JSON objects, for example `{"one":1,"two":2}`.
 8. By default, JSON nulls are decoded to Lua `nil` and treated by Lua in the normal way (for example, they appear not to exist &mdash; see [json.decode()][api.library.json.decode]).
+
+
+## Gotchas
+
+JSON has two collection types, arrays (`[]`) and objects (`{}`), but Lua has only the table, so `json.encode()` has to pick one. A table is encoded as an array when all of its keys are positive integers (gaps are permitted), and as an object the moment any non-integer key is present.
+
+Because JSON object keys are always strings, every key in an object-encoded table is stringified, integer keys included. Adding a single key that isn't a positive integer therefore changes how the entire table is encoded, including its positive-integer keys:
+
+``````lua
+local json = require( "json" )
+
+local t1 = {
+	[1] = 1,
+	[2] = 2,
+	[3] = 3,
+}
+print( json.encode( t1 ) )  --> [1,2,3]
+
+local t2 = {
+	[1] = 1,
+	[2] = 2,
+	[3] = 3,
+	["a"] = "a",
+}
+print( json.encode( t2 ) )  --> {"1":1,"2":2,"a":"a","3":3}
+``````
+
+Two consequences follow:
+
+1. __Round-tripping does not preserve integer keys.__ `json.decode( json.encode( t2 ) )` returns a table keyed by the strings `"1"`, `"2"`, `"3"`, not the integers `1`, `2`, `3`. Code that later indexes with `t[1]` will get `nil`.
+2. __Key order in an object is not guaranteed.__ Do not rely on the position of keys in the encoded string.
 
 
 ## Examples

--- a/markdown/guide/distribution/advancedSettings/index.markdown
+++ b/markdown/guide/distribution/advancedSettings/index.markdown
@@ -27,6 +27,39 @@ This guide is intended for those who require more specialized configuration opti
 
 ## Advanced Settings &mdash; iOS
 
+### Minimum iOS Version
+
+Providing a minimum iOS version with the `MinimumOSVersion` key allows you to exclude your app from being installed on devices with older versions of iOS. It's specified within the <nobr>`iphone` &rarr; `plist`</nobr> table and corresponds to Apple's [`MinimumOSVersion`](https://developer.apple.com/documentation/BundleResources/Information-Property-List/MinimumOSVersion) property list key.
+
+``````{ brush="lua" gutter="false" first-line="1" highlight="[7]" }
+settings =
+{
+	iphone =
+	{
+		plist =
+		{
+			MinimumOSVersion = "11.0",
+		},
+	},
+}
+``````
+
+<div class="guide-notebox">
+<div class="notebox-title">Notes</div>
+
+* The value must be specified as a __string__ <nobr>(e.g. `"11.0"`)</nobr>. A numeric value such as `11.0` is ignored and the default minimum version is used instead.
+
+* If not specified, the minimum version defaults to `"8.0"`, the lowest version of iOS that Solar2D supports. However, when building against iOS&nbsp;SDK&nbsp;16.4 or later, Solar2D raises any value below `"11.0"` up to `"11.0"`. Since current versions of Xcode ship newer SDKs, `"11.0"` is effectively the lowest value you can target.
+
+</div>
+
+<div class="guide-notebox-imp">
+<div class="notebox-title-imp">Important</div>
+
+If a plugin you use requires a newer version of iOS than your app's minimum, Solar2D does __not__ raise `MinimumOSVersion` automatically to accommodate it. You must set it yourself to match the highest iOS version required by any of your plugins, otherwise the build can fail. Some plugins, such as [Appodeal][plugin.appodeal], document the exact value they require.
+
+</div>
+
 ### Device Capabilities
 
 If you wish to limit your iOS app to devices with specific capabilities, you can include the optional `UIRequiredDeviceCapabilities` key within the <nobr>`iphone` &rarr; `plist`</nobr> table. The value of this key should be a table containing specific keys matching Apple's [documentation](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/uid/TP40009252-SW3). For&nbsp;example:


### PR DESCRIPTION
The docs had a section on minimum SDK version for Android, but it was missing minimum iOS version section on the same page. The property was just referenced in some plugins' pages.